### PR TITLE
fix and improve rotation recovery

### DIFF
--- a/rotate_recovery/CMakeLists.txt
+++ b/rotate_recovery/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
         pluginlib
 )
 
-add_library(rotate_recovery src/rotate_recovery.cpp)
+add_library(rotate_recovery src/rotate_recovery.cpp src/negative_rotate_recovery.cpp)
 add_dependencies(rotate_recovery ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(rotate_recovery ${catkin_LIBRARIES})
 

--- a/rotate_recovery/include/rotate_recovery/negative_rotate_recovery.h
+++ b/rotate_recovery/include/rotate_recovery/negative_rotate_recovery.h
@@ -1,0 +1,12 @@
+#ifndef NEGATIVE_ROTATE_RECOVERY_H_
+#define NEGATIVE_ROTATE_RECOVERY_H_
+#include <rotate_recovery/rotate_recovery.h>
+
+namespace rotate_recovery {
+class NegativeRotateRecovery : public rotate_recovery::RotateRecovery {
+public:
+  NegativeRotateRecovery();
+};
+
+}  // namespace rotate_recovery
+#endif

--- a/rotate_recovery/include/rotate_recovery/rotate_recovery.h
+++ b/rotate_recovery/include/rotate_recovery/rotate_recovery.h
@@ -78,6 +78,9 @@ namespace rotate_recovery{
        */
       ~RotateRecovery();
 
+    protected:
+      bool rotate_positive_;
+
     private:
       costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
       costmap_2d::Costmap2D costmap_;

--- a/rotate_recovery/rotate_plugin.xml
+++ b/rotate_recovery/rotate_plugin.xml
@@ -1,7 +1,12 @@
 <library path="lib/librotate_recovery">
   <class name="rotate_recovery/RotateRecovery" type="rotate_recovery::RotateRecovery" base_class_type="nav_core::RecoveryBehavior">
     <description>
-      A recovery behavior that performs a 360 degree in-place rotation to attempt to clear out space.
+      A recovery behavior that performs a 360 degree in-place rotation in positive direction to attempt to clear out space.
+    </description>
+  </class>
+  <class name="rotate_recovery/NegativeRotateRecovery" type="rotate_recovery::NegativeRotateRecovery" base_class_type="nav_core::RecoveryBehavior">
+    <description>
+      A recovery behavior that performs a 360 degree in-place rotation in negative direction to attempt to clear out space.
     </description>
   </class>
 </library>

--- a/rotate_recovery/src/negative_rotate_recovery.cpp
+++ b/rotate_recovery/src/negative_rotate_recovery.cpp
@@ -1,0 +1,11 @@
+#include <rotate_recovery/negative_rotate_recovery.h>
+#include <pluginlib/class_list_macros.h>
+
+// register this planner as a RecoveryBehavior plugin
+PLUGINLIB_EXPORT_CLASS(rotate_recovery::NegativeRotateRecovery, nav_core::RecoveryBehavior)
+
+namespace rotate_recovery {
+
+NegativeRotateRecovery::NegativeRotateRecovery() {rotate_positive_= false;}
+
+};  // namespace rotate_recovery

--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -127,7 +127,7 @@ void RotateRecovery::runBehavior(){
       if(footprint_cost < 0.0){
         // only allow to rotate to the obstacle, minus some buffer
         dist_left = sim_angle - 2 * max_stopping_distance;
-        if (dist_left < 0) {
+        if (dist_left <= 0) {
           ROS_ERROR("Rotate recovery stops rotating in place because there is a potential collision. Cost: %.2f", footprint_cost);
           geometry_msgs::Twist cmd_vel;
           cmd_vel.linear.x = 0.0;


### PR DESCRIPTION
This PR (as described in the individual commit messages):
- fixes the logic in the rotate recovery behavior
- generalizes the rotation direction
- adds a feature that the robot will attempt to rotate as far as it can without a collision, instead of only rotating when the full 360 degree rotation is expected to not collide
- adds the negative rotate recovery behavior to the rotate_recovery package

Tested in simulation.