### PR TITLE
prevent fast accelerations while turning to reduce risk of slip

### DIFF
--- a/base_local_planner/src/simple_trajectory_generator.cpp
+++ b/base_local_planner/src/simple_trajectory_generator.cpp
@@ -105,7 +105,14 @@ void SimpleTrajectoryGenerator::initialise(
       min_vel[2] = std::max(min_vel_th, vel[2] - acc_lim[2] * sim_time_);
     } else {
       // with dwa do not accelerate beyond the first step, we only sample within velocities we reach in sim_period
-      max_vel[0] = std::min(max_vel_x, vel[0] + acc_lim[0] * sim_period_);
+      if (vel[0] + acc_lim[0] * sim_period_ <= 0.0) {
+        max_vel[0] = vel[0] + acc_lim[0] * sim_period_;
+      }
+      else {
+        // prevent fast accelerations while turning to reduce risk of slip
+        max_vel[0] = std::min(max_vel_x, std::max(0.0, vel[0] + std::max(0.0,
+                acc_lim[0] * sim_period_ * (max_vel_th - 2.0 * std::fabs(vel[2])))));
+      }
       max_vel[1] = std::min(max_vel_y, vel[1] + acc_lim[1] * sim_period_);
       max_vel[2] = std::min(max_vel_th, vel[2] + acc_lim[2] * sim_period_);
 

--- a/base_local_planner/src/simple_trajectory_generator.cpp
+++ b/base_local_planner/src/simple_trajectory_generator.cpp
@@ -111,7 +111,7 @@ void SimpleTrajectoryGenerator::initialise(
       else {
         // prevent fast accelerations while turning to reduce risk of slip
         max_vel[0] = std::min(max_vel_x, std::max(0.0, vel[0] + std::max(0.0,
-                acc_lim[0] * sim_period_ * (max_vel_th - 2.0 * std::fabs(vel[2])))));
+                acc_lim[0] * sim_period_ * (1.0 - 2.0 * std::fabs(vel[2])))));
       }
       max_vel[1] = std::min(max_vel_y, vel[1] + acc_lim[1] * sim_period_);
       max_vel[2] = std::min(max_vel_th, vel[2] + acc_lim[2] * sim_period_);


### PR DESCRIPTION
Disallows large forward accelerations during turns, to reduce risk of slip.

A bit of a hack, I would have preferred to take care of this by a trajectory scoring function, but that would require reverse engineering the acceleration in the scoring function (and generally be much larger changes).
I can do it now if we want; I would suggest to do that later.