### PR TITLE
Fix footprint scaling

### DIFF
--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -70,8 +70,7 @@ public:
       const double& x,
       const double& y,
       const double& th,
-      double scale,
-      std::vector<geometry_msgs::Point> footprint_spec,
+      const std::vector<geometry_msgs::Point>& footprint_spec,
       costmap_2d::Costmap2D* costmap,
       base_local_planner::WorldModel* world_model);
 

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -70,7 +70,7 @@ public:
       const double& x,
       const double& y,
       const double& th,
-      const std::vector<geometry_msgs::Point>& footprint_spec,
+      const std::vector<geometry_msgs::Point>& scaled_footprint,
       costmap_2d::Costmap2D* costmap,
       base_local_planner::WorldModel* world_model);
 

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -39,7 +39,6 @@
 #include <cmath>
 #include <Eigen/Core>
 #include <ros/console.h>
-#include <costmap_2d/cost_values.h>
 
 namespace base_local_planner {
 
@@ -130,12 +129,6 @@ double ObstacleCostFunction::footprintCost (
   if (footprint_cost < 0) {
     return -6.0;
   }
-
-  // hack to get robot away from obstacles
-  if (footprint_cost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
-      return 2 * footprint_cost;
-  }
-
   unsigned int cell_x, cell_y;
 
   //we won't allow trajectories that go off the map... shouldn't happen that often anyways

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -81,18 +81,18 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     return -9;
   }
 
-  std::vector<geometry_msgs::Point> footprint_scaled = footprint_spec_;
+  std::vector<geometry_msgs::Point> scaled_footprint = footprint_spec_;
   if (scale != 1.0) {
-    for (unsigned int i = 0; i < footprint_scaled.size(); ++i) {
-      footprint_scaled[i].x *= scale;
-      footprint_scaled[i].y *= scale;
+    for (unsigned int i = 0; i < scaled_footprint.size(); ++i) {
+      scaled_footprint[i].x *= scale;
+      scaled_footprint[i].y *= scale;
     }
   }
 
   for (unsigned int i = 0; i < traj.getPointsSize(); ++i) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
-        footprint_scaled,
+        scaled_footprint,
         costmap_, world_model_);
 
     if(f_cost < 0){
@@ -125,13 +125,13 @@ double ObstacleCostFunction::footprintCost (
     const double& x,
     const double& y,
     const double& th,
-    const std::vector<geometry_msgs::Point>& footprint_spec,
+    const std::vector<geometry_msgs::Point>& scaled_footprint,
     costmap_2d::Costmap2D* costmap,
     base_local_planner::WorldModel* world_model) {
 
   //check if the footprint is legal
   // TODO: Cache inscribed radius
-  double footprint_cost = world_model->footprintCost(x, y, th, footprint_spec);
+  double footprint_cost = world_model->footprintCost(x, y, th, scaled_footprint);
 
   if (footprint_cost < 0) {
     return -6.0;

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -81,10 +81,18 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     return -9;
   }
 
+  std::vector<geometry_msgs::Point> footprint_scaled = footprint_spec_;
+  if (scale != 1.0) {
+    for (unsigned int i = 0; i < footprint_scaled.size(); ++i) {
+      footprint_scaled[i].x *= scale;
+      footprint_scaled[i].y *= scale;
+    }
+  }
+
   for (unsigned int i = 0; i < traj.getPointsSize(); ++i) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
-        scale, footprint_spec_,
+        footprint_scaled,
         costmap_, world_model_);
 
     if(f_cost < 0){
@@ -117,8 +125,7 @@ double ObstacleCostFunction::footprintCost (
     const double& x,
     const double& y,
     const double& th,
-    double scale,
-    std::vector<geometry_msgs::Point> footprint_spec,
+    const std::vector<geometry_msgs::Point>& footprint_spec,
     costmap_2d::Costmap2D* costmap,
     base_local_planner::WorldModel* world_model) {
 


### PR DESCRIPTION
Reverts a previous hack increasing near obstacle costs, which is not required anymore since this PR fixes the broken footprint scaling.