### PR TITLE
Small tweaking

### DIFF
--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -89,7 +89,10 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     }
   }
 
-  for (unsigned int i = 0; i < traj.getPointsSize(); ++i) {
+  const unsigned int point_size = traj.getPointsSize();
+  // ignore first trajectory point since it is the same for all trajectories,
+  // unless trajectory only contains one point
+  for (unsigned int i = point_size > 1 ? 1 : 0; i < point_size; ++i) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
         scaled_footprint,

--- a/base_local_planner/src/simple_trajectory_generator.cpp
+++ b/base_local_planner/src/simple_trajectory_generator.cpp
@@ -105,14 +105,15 @@ void SimpleTrajectoryGenerator::initialise(
       min_vel[2] = std::max(min_vel_th, vel[2] - acc_lim[2] * sim_time_);
     } else {
       // with dwa do not accelerate beyond the first step, we only sample within velocities we reach in sim_period
-      if (vel[0] + acc_lim[0] * sim_period_ <= 0.0) {
-        max_vel[0] = vel[0] + acc_lim[0] * sim_period_;
-      }
-      else {
+      max_vel_x = std::min(max_vel_x, vel[0] + acc_lim[0] * sim_period_);
+      if (max_vel_x <= limits_->min_trans_vel) {
+        max_vel[0] = max_vel_x;
+      } else {
         // prevent fast accelerations while turning to reduce risk of slip
-        max_vel[0] = std::min(max_vel_x, std::max(0.0, vel[0] + std::max(0.0,
-                acc_lim[0] * sim_period_ * (1.0 - 2.0 * std::fabs(vel[2])))));
+        max_vel[0] = std::max(limits_->min_trans_vel,
+            vel[0] + std::max(0.0, acc_lim[0] * sim_period_ * (1.0 - 2.0 * std::fabs(vel[2]))));
       }
+
       max_vel[1] = std::min(max_vel_y, vel[1] + acc_lim[1] * sim_period_);
       max_vel[2] = std::min(max_vel_th, vel[2] + acc_lim[2] * sim_period_);
 

--- a/base_local_planner/src/simple_trajectory_generator.cpp
+++ b/base_local_planner/src/simple_trajectory_generator.cpp
@@ -110,8 +110,8 @@ void SimpleTrajectoryGenerator::initialise(
         max_vel[0] = max_vel_x;
       } else {
         // prevent fast accelerations while turning to reduce risk of slip
-        max_vel[0] = std::max(limits_->min_trans_vel,
-            vel[0] + std::max(0.0, acc_lim[0] * sim_period_ * (1.0 - 2.0 * std::fabs(vel[2]))));
+        max_vel[0] = std::min(max_vel_x, std::max(limits_->min_trans_vel,
+            vel[0] + std::max(0.0, acc_lim[0] * sim_period_ * (1.0 - 2.0 * std::fabs(vel[2])))));
       }
 
       max_vel[1] = std::min(max_vel_y, vel[1] + acc_lim[1] * sim_period_);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -276,9 +276,9 @@ namespace dwa_local_planner {
     std::vector<geometry_msgs::PoseStamped> front_global_plan = global_plan_;
     double angle_to_goal = atan2(goal_pose.pose.position.y - pos[1], goal_pose.pose.position.x - pos[0]);
     front_global_plan.back().pose.position.x = front_global_plan.back().pose.position.x +
-      abs(forward_point_distance_) * cos(angle_to_goal);
+      std::abs(forward_point_distance_) * cos(angle_to_goal);
     front_global_plan.back().pose.position.y = front_global_plan.back().pose.position.y +
-      abs(forward_point_distance_) * sin(angle_to_goal);
+      std::abs(forward_point_distance_) * sin(angle_to_goal);
 
     goal_front_costs_.setTargetPoses(front_global_plan);
     


### PR DESCRIPTION
3 independent commits:
- ignore first trajectory point since it is the same for all trajectories, unless trajectory only contains one point
- allow accelerating to min_trans_vel during fast turns (such that robot is allowed to move forward during turns, e.g. in aisles)
- fix previous forward point distance change