### PR TITLE
Fix oscillation flags

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_util.h
+++ b/base_local_planner/include/base_local_planner/local_planner_util.h
@@ -95,6 +95,8 @@ public:
 
   bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
 
+  const std::vector<geometry_msgs::PoseStamped>& getGlobalPlan() const {return global_plan_;};
+
   bool getLocalPlan(tf::Stamped<tf::Pose>& global_pose, std::vector<geometry_msgs::PoseStamped>& transformed_plan);
 
   costmap_2d::Costmap2D* getCostmap();

--- a/base_local_planner/src/oscillation_cost_function.cpp
+++ b/base_local_planner/src/oscillation_cost_function.cpp
@@ -66,6 +66,10 @@ void OscillationCostFunction::updateOscillationFlags(Eigen::Vector3f pos, base_l
       resetOscillationFlagsIfPossible(pos, prev_stationary_pos_);
     }
   }
+  else {
+    resetOscillationFlags();
+    prev_stationary_pos_ = pos;
+  }
 }
 
 void OscillationCostFunction::resetOscillationFlagsIfPossible(const Eigen::Vector3f& pos, const Eigen::Vector3f& prev) {

--- a/base_local_planner/src/oscillation_cost_function.cpp
+++ b/base_local_planner/src/oscillation_cost_function.cpp
@@ -38,6 +38,7 @@
 #include <base_local_planner/oscillation_cost_function.h>
 
 #include <cmath>
+#include <angles/angles.h>
 
 namespace base_local_planner {
 
@@ -72,7 +73,7 @@ void OscillationCostFunction::resetOscillationFlagsIfPossible(const Eigen::Vecto
   double y_diff = pos[1] - prev[1];
   double sq_dist = x_diff * x_diff + y_diff * y_diff;
 
-  double th_diff = pos[2] - prev[2];
+  double th_diff = angles::normalize_angle(pos[2] - prev[2]);
 
   //if we've moved far enough... we can reset our flags
   if (sq_dist > oscillation_reset_dist_ * oscillation_reset_dist_ ||

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -205,8 +205,18 @@ namespace dwa_local_planner {
     return true;
   }
 
+  inline bool is2DPoseEqual(const geometry_msgs::PoseStamped& a, const geometry_msgs::PoseStamped& b) {
+    return a.pose.position.x == b.pose.position.x && a.pose.position.y == b.pose.position.y &&
+        a.pose.orientation.z * (a.pose.orientation.w >= 0 ? 1 : -1) ==
+            b.pose.orientation.z * (b.pose.orientation.w >= 0 ? 1 : -1);
+  }
+
   bool DWAPlanner::setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan) {
-    oscillation_costs_.resetOscillationFlags();
+    const std::vector<geometry_msgs::PoseStamped>& prevPlan = planner_util_->getGlobalPlan();
+    // conservatively reset oscillation flags: reset only for plan towards different goal
+    if (orig_global_plan.empty() || prevPlan.empty() || !is2DPoseEqual(prevPlan.back(), orig_global_plan.back())) {
+      oscillation_costs_.resetOscillationFlags();
+    }
     return planner_util_->setPlan(orig_global_plan);
   }
 

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -207,8 +207,7 @@ namespace dwa_local_planner {
 
   inline bool is2DPoseEqual(const geometry_msgs::PoseStamped& a, const geometry_msgs::PoseStamped& b) {
     return a.pose.position.x == b.pose.position.x && a.pose.position.y == b.pose.position.y &&
-        a.pose.orientation.z * (a.pose.orientation.w >= 0 ? 1 : -1) ==
-            b.pose.orientation.z * (b.pose.orientation.w >= 0 ? 1 : -1);
+        a.pose.orientation.z * b.pose.orientation.w == a.pose.orientation.w * b.pose.orientation.z;
   }
 
   bool DWAPlanner::setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan) {


### PR DESCRIPTION
(will change target branch to rr-devel once [small_tweaking](https://github.com/rapyuta-robotics/ros-navigation/pull/20) is merged)

At the current state, the oscillation flags in the local planner (preventing oscillating back and forth between solutions) don't work since the global planner plans at 3Hz, resetting the flags.
This PR addresses this problem by not resetting the flags if the new plan from the global planner goes to the same goal (which is the simplest way of conservatively detecting the plan "changed"). Additionally, in case no valid trajectory can be found, the flags **are** reset.