### PR TITLE
change footprint scaling to absolute forward and sideward inflation

### DIFF
--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -61,11 +61,11 @@ public:
 
   void setSumScores(bool score_sums){ sum_scores_=score_sums; }
 
-  void setParams(double max_trans_vel, double max_scaling_factor, double scaling_speed);
+  void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed);
   void setFootprint(std::vector<geometry_msgs::Point> footprint_spec);
 
   // helper functions, made static for easy unit testing
-  static double getScalingFactor(Trajectory &traj, double scaling_speed, double max_trans_vel, double max_scaling_factor);
+  static double getScalingFactor(Trajectory &traj, double scaling_speed, double max_trans_vel);
   static double footprintCost(
       const double& x,
       const double& y,
@@ -81,7 +81,7 @@ private:
   double max_trans_vel_;
   bool sum_scores_;
   //footprint scaling with velocity;
-  double max_scaling_factor_, scaling_speed_;
+  double max_forward_inflation_, max_sideward_inflation_, scaling_speed_;
 };
 
 } /* namespace base_local_planner */

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -26,7 +26,8 @@ gen.add("oscillation_reset_angle", double_t, 0, "The angle the robot must turn b
 gen.add("forward_point_distance", double_t, 0, "The distance from the center point of the robot to place an additional scoring point, in meters", 0.325)
 
 gen.add("scaling_speed", double_t, 0, "The absolute value of the velocity at which to start scaling the robot's footprint, in m/s", 0.25, 0)
-gen.add("max_scaling_factor", double_t, 0, "The maximum factor to scale the robot's footprint by", 0.2, 0)
+gen.add("max_forward_inflation", double_t, 0, "The maximum length the robot's footprint is extended forward by", 0.2, 0)
+gen.add("max_sideward_inflation", double_t, 0, "The maximum length the robot's footprint is extended sidewards by", 0.2, 0)
 
 gen.add("vx_samples", int_t, 0, "The number of samples to use when exploring the x velocity space", 3, 1)
 gen.add("vy_samples", int_t, 0, "The number of samples to use when exploring the y velocity space", 10, 1)

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -81,7 +81,7 @@ namespace dwa_local_planner {
     alignment_costs_.setXShift(forward_point_distance_);
  
     // obstacle costs can vary due to scaling footprint feature
-    obstacle_costs_.setParams(config.max_vel_trans, config.max_scaling_factor, config.scaling_speed);
+    obstacle_costs_.setParams(config.max_vel_trans, config.max_forward_inflation, config.max_sideward_inflation, config.scaling_speed);
 
     twirling_costs_.setScale(config.twirling_scale);
 


### PR DESCRIPTION
This is the PR to incorporate a cleaned up version of this commit (https://github.com/rapyuta-robotics/ros-navigation/commit/b3f33b0b1937b521c019f788bb44bdba623d7438) that we have been testing for quite a while now. I just waited to make a PR until the melodic shift was complete.