### PR TITLE
Minimize backwards motion

### DIFF
--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -5,6 +5,8 @@
 
 namespace base_local_planner {
 
+constexpr double MAX_ANGLE_ERROR = 0.8;
+
 class AlignWithPathFunction : public base_local_planner::TrajectoryCostFunction {
 public:
   AlignWithPathFunction();
@@ -15,8 +17,12 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
+  bool isTurningRequired() const {
+    return std::abs(current_yaw_diff_) > MAX_ANGLE_ERROR;
+  }
+
 private:
-  bool current_yaw_diff_positive_;
+  double current_yaw_diff_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -9,17 +9,14 @@ class AlignWithPathFunction : public base_local_planner::TrajectoryCostFunction 
 public:
   AlignWithPathFunction();
 
-  void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses);
+  void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose);
 
   bool prepare();
 
   double scoreTrajectory(Trajectory &traj);
 
 private:
-  double path_yaw_;
-  double goal_x_;
-  double goal_y_;
-  bool target_pose_valid_;
+  bool current_yaw_diff_positive_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
+++ b/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
@@ -44,20 +44,9 @@ namespace base_local_planner {
 
 class PreferForwardCostFunction: public base_local_planner::TrajectoryCostFunction {
 public:
-
-  PreferForwardCostFunction(double penalty) : penalty_(penalty) {}
-  ~PreferForwardCostFunction() {}
-
   double scoreTrajectory(Trajectory &traj);
 
   bool prepare() {return true;};
-
-  void setPenalty(double penalty) {
-    penalty_ = penalty;
-  }
-
-private:
-  double penalty_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -4,16 +4,13 @@
 
 namespace base_local_planner {
 
-constexpr double MAX_ANGLE_ERROR = 0.8;
 constexpr double MIN_ROT_SPEED = 0.1;
-constexpr double MIN_GOAL_DIST_SQ = 0.7;
 constexpr double PENALTY_COST = 1e6;
 
-AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_positive_(true) {}
+AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0) {}
 
 void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose) {
-  setScale(0);
-
+  current_yaw_diff_ = 0;
   const int num_points = target_poses.size();
   if (num_points <= 0) {
     return;
@@ -21,25 +18,9 @@ void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStampe
   // todo: decide which point to pick
   geometry_msgs::PoseStamped path_node =  *(target_poses.begin() + std::min(3, num_points-1));
   const double path_yaw = 2 * atan2 (path_node.pose.orientation.z, path_node.pose.orientation.w);
-  const double goal_dx = target_poses.back().pose.position.x - global_pose.pose.position.x;
-  const double goal_dy = target_poses.back().pose.position.y - global_pose.pose.position.y;
-
-  const double squared_dist = goal_dx * goal_dx + goal_dy * goal_dy;
-  if (squared_dist < MIN_GOAL_DIST_SQ)
-  {
-    return;
-  }
 
   const double current_yaw = 2 * atan2(global_pose.pose.orientation.z, global_pose.pose.orientation.w);
-  const double current_yaw_diff = angles::normalize_angle(path_yaw - current_yaw);
-
-  current_yaw_diff_positive_ = current_yaw_diff > 0;
-
-  if (std::abs(current_yaw_diff) < MAX_ANGLE_ERROR)
-  {
-    return;
-  }
-  setScale(1);
+  current_yaw_diff_ = angles::normalize_angle(path_yaw - current_yaw);
 }
 
 bool AlignWithPathFunction::prepare() {
@@ -47,11 +28,15 @@ bool AlignWithPathFunction::prepare() {
 }
 
 double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {
+  if (!isTurningRequired()) {
+    return 0;
+  }
+
   // if angle off by more than MAX_ANGLE_ERROR, force to rotate towards path with more than MIN_ROT_SPEED
-  if (current_yaw_diff_positive_ && traj.thetav_ < MIN_ROT_SPEED) {
+  if (current_yaw_diff_ > 0 && traj.thetav_ < MIN_ROT_SPEED) {
     return PENALTY_COST;
   }
-  if (!current_yaw_diff_positive_ && traj.thetav_ > -MIN_ROT_SPEED) {
+  if (current_yaw_diff_ < 0 && traj.thetav_ > -MIN_ROT_SPEED) {
     return PENALTY_COST;
   }
   return 0;

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -107,7 +107,6 @@ namespace base_local_planner{
     unsigned char cost = costmap.getCost(check_cell->cx, check_cell->cy);
     if(! getCell(check_cell->cx, check_cell->cy).within_robot &&
         (cost == costmap_2d::LETHAL_OBSTACLE ||
-         cost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
          cost == costmap_2d::NO_INFORMATION)){
       check_cell->target_dist = obstacleCosts();
       return false;

--- a/base_local_planner/src/map_grid_cost_function.cpp
+++ b/base_local_planner/src/map_grid_cost_function.cpp
@@ -36,6 +36,7 @@
  *********************************************************************/
 
 #include <base_local_planner/map_grid_cost_function.h>
+#include <costmap_2d/cost_values.h>
 
 namespace base_local_planner {
 
@@ -106,7 +107,11 @@ double MapGridCostFunction::scoreTrajectory(Trajectory &traj) {
     if (stop_on_failure_) {
       if (grid_dist == map_.obstacleCosts()) {
         return -3.0;
-      } else if (grid_dist == map_.unreachableCellCosts()) {
+      }
+      if (grid_dist == costmap_2d::INSCRIBED_INFLATED_OBSTACLE && xshift_ == 0 && yshift_ == 0) {
+        return -3.0;
+      }
+      if (grid_dist == map_.unreachableCellCosts()) {
         return -2.0;
       }
     }

--- a/base_local_planner/src/prefer_forward_cost_function.cpp
+++ b/base_local_planner/src/prefer_forward_cost_function.cpp
@@ -15,14 +15,9 @@ namespace base_local_planner {
 double PreferForwardCostFunction::scoreTrajectory(Trajectory &traj) {
   // backward motions bad on a robot without backward sensors
   if (traj.xv_ < 0.0) {
-    return penalty_;
+    return -traj.xv_;
   }
-  // strafing motions also bad on such a robot
-  if (traj.xv_ < 0.1 && fabs(traj.thetav_) < 0.2) {
-    return penalty_;
-  }
-  // the more we rotate, the less we progress forward
-  return fabs(traj.thetav_) * 10;
+  return 0;
 }
 
 } /* namespace base_local_planner */

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -58,6 +58,7 @@
 #include <base_local_planner/oscillation_cost_function.h>
 #include <base_local_planner/map_grid_cost_function.h>
 #include <base_local_planner/obstacle_cost_function.h>
+#include <base_local_planner/prefer_forward_cost_function.h>
 #include <base_local_planner/twirling_cost_function.h>
 #include <base_local_planner/simple_scored_sampling_planner.h>
 
@@ -180,6 +181,7 @@ namespace dwa_local_planner {
       base_local_planner::MapGridCostFunction goal_front_costs_;
       base_local_planner::MapGridCostFunction alignment_costs_;
       base_local_planner::TwirlingCostFunction twirling_costs_;
+      base_local_planner::PreferForwardCostFunction prefer_forward_costs_;
 
       base_local_planner::SimpleScoredSamplingPlanner scored_sampling_planner_;
   };

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -151,7 +151,7 @@ namespace dwa_local_planner {
       base_local_planner::LocalPlannerUtil *planner_util_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop
-      double pdist_scale_, gdist_scale_, occdist_scale_;
+      double pdist_scale_, gdist_scale_, occdist_scale_, backwardvel_scale_;
       Eigen::Vector3f vsamples_;
 
       double sim_period_;///< @brief The number of seconds to use to compute max/min vels for dwa

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,7 +85,7 @@ namespace dwa_local_planner {
 
     twirling_costs_.setScale(config.twirling_scale);
 
-    prefer_forward_costs_.setScale(1.2 * config.sim_time * (2 * config.goal_distance_bias + config.path_distance_bias));
+    prefer_forward_costs_.setScale(1.2 * config.sim_time * (config.path_distance_bias + config.goal_distance_bias));
 
     int vx_samp, vy_samp, vth_samp;
     vx_samp = config.vx_samples;
@@ -288,12 +288,18 @@ namespace dwa_local_planner {
     front_global_plan.back().pose.position.y = front_global_plan.back().pose.position.y + std::abs(forward_point_distance_) * sin(angle_to_goal);
 
     goal_front_costs_.setTargetPoses(front_global_plan);
-    
+
     // keeping the nose on the path
     if (sq_dist > forward_point_distance_ * forward_point_distance_ * cheat_factor_) {
-      alignment_costs_.setScale(pdist_scale_);
-      // costs for robot being aligned with path (nose on path, not ju
-      alignment_costs_.setTargetPoses(global_plan_);
+      if (path_align_costs_.getScale() == 0) {
+        alignment_costs_.setScale(pdist_scale_);
+        goal_front_costs_.setScale(gdist_scale_);
+        // costs for robot being aligned with path (nose on path, not ju
+        alignment_costs_.setTargetPoses(global_plan_);
+      } else {
+         alignment_costs_.setScale(0.0);
+         goal_front_costs_.setScale(0.0);
+      }
     } else {
       // once we are close to goal, trying to keep the nose close to anything destabilizes behavior.
       alignment_costs_.setScale(0.0);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -257,7 +257,7 @@ namespace dwa_local_planner {
 
     obstacle_costs_.setFootprint(footprint_spec);
 
-    path_align_costs_.setTargetPoses(global_plan_);
+    path_align_costs_.setTargetPoses(global_plan_, global_pose);
 
     // costs for going away from path
     path_costs_.setTargetPoses(global_plan_);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,6 +85,8 @@ namespace dwa_local_planner {
 
     twirling_costs_.setScale(config.twirling_scale);
 
+    prefer_forward_costs_.setScale(1.2 * config.sim_time * (2 * config.goal_distance_bias + config.path_distance_bias));
+
     int vx_samp, vy_samp, vth_samp;
     vx_samp = config.vx_samples;
     vy_samp = config.vy_samples;
@@ -171,6 +173,7 @@ namespace dwa_local_planner {
     critics.push_back(&alignment_costs_); // prefers trajectories that keep the robot nose on nose path
     critics.push_back(&path_costs_); // prefers trajectories on global path
     critics.push_back(&goal_costs_); // prefers trajectories that go towards (local) goal, based on wave propagation
+    critics.push_back(&prefer_forward_costs_); // prefer trajectories that don't go backwards
     critics.push_back(&twirling_costs_); // optionally prefer trajectories that don't spin
 
     // trajectory generators


### PR DESCRIPTION
 [Wrike task](https://www.wrike.com/open.htm?id=447700145)
exposed a `isTurningRequired` method to the `AlignWithPathFunction` class, and depending on what this returns, different critics are enabled / disabled in the DWA planner. 
Also contains some related improvements / cleanup