### PR TITLE
Rotate nose into inscribed region

### DIFF
--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -107,6 +107,7 @@ namespace base_local_planner{
     unsigned char cost = costmap.getCost(check_cell->cx, check_cell->cy);
     if(! getCell(check_cell->cx, check_cell->cy).within_robot &&
         (cost == costmap_2d::LETHAL_OBSTACLE ||
+         cost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
          cost == costmap_2d::NO_INFORMATION)){
       check_cell->target_dist = obstacleCosts();
       return false;

--- a/base_local_planner/src/map_grid_cost_function.cpp
+++ b/base_local_planner/src/map_grid_cost_function.cpp
@@ -36,7 +36,6 @@
  *********************************************************************/
 
 #include <base_local_planner/map_grid_cost_function.h>
-#include <costmap_2d/cost_values.h>
 
 namespace base_local_planner {
 
@@ -107,11 +106,7 @@ double MapGridCostFunction::scoreTrajectory(Trajectory &traj) {
     if (stop_on_failure_) {
       if (grid_dist == map_.obstacleCosts()) {
         return -3.0;
-      }
-      if (grid_dist == costmap_2d::INSCRIBED_INFLATED_OBSTACLE && xshift_ == 0 && yshift_ == 0) {
-        return -3.0;
-      }
-      if (grid_dist == map_.unreachableCellCosts()) {
+      } else if (grid_dist == map_.unreachableCellCosts()) {
         return -2.0;
       }
     }

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -299,6 +299,11 @@ namespace dwa_local_planner {
       goal_costs_.setScale(0.0);
       // disable alignment cost during turning because turning will inadvertedly move the nose off the path
       alignment_costs_.setScale(0.0);
+
+      // retract nose
+      goal_front_costs_.setXShift(0.0);
+      alignment_costs_.setXShift(0.0);
+
     } else {
       // disable turning penalty close to goal
       path_align_costs_.setScale(0.0);
@@ -312,6 +317,10 @@ namespace dwa_local_planner {
         // once we are close to goal, trying to keep the nose close to anything destabilizes behavior.
         alignment_costs_.setScale(0.0);
       }
+
+      // reset to forward_point_distance_
+      goal_front_costs_.setXShift(forward_point_distance_);
+      alignment_costs_.setXShift(forward_point_distance_);
     }
 
     // disable cost for backwards motion close to the goal


### PR DESCRIPTION
I reverted that earlier [commit](https://github.com/rapyuta-robotics/ros-navigation/commit/9414f82820e2325e89486b1bdf36b243f8e4fef9) that doesn't work completely as intended / also allowing to fill cells in the `INSCRIBED_INFLATED_OBSTACLE` region will give wrong hope of fitting through a narrow gap.

Instead, the nose should just be retracted during rotation, such that the nose can be rotated through regions with `INSCRIBED_INFLATED_OBSTACLE` cost