### PR TITLE
Fix/chr dwa planner goal latching

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -148,7 +148,7 @@ namespace dwa_local_planner {
 
       base_local_planner::LatchedStopRotateController latchedStopRotateController_;
 
-      geometry_msgs::PoseStamped previous_goal;
+      geometry_msgs::PoseStamped previous_goal_;
 
       bool initialized_;
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -148,7 +148,7 @@ namespace dwa_local_planner {
 
       base_local_planner::LatchedStopRotateController latchedStopRotateController_;
 
-      geometry_msgs::PoseStamped previous_goal_;
+      geometry_msgs::PoseStamped current_goal_;
 
       bool initialized_;
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -148,6 +148,7 @@ namespace dwa_local_planner {
 
       base_local_planner::LatchedStopRotateController latchedStopRotateController_;
 
+      geometry_msgs::PoseStamped previous_goal;
 
       bool initialized_;
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -145,13 +145,13 @@ namespace dwa_local_planner {
       return false;
     }
 
-    if (orig_global_plan.empty() || orig_global_plan.back().pose != previous_goal_.pose
-            || orig_global_plan.back().header.frame_id != previous_goal_.header.frame_id) {
+    if (orig_global_plan.empty() || orig_global_plan.back().pose != current_goal_.pose
+            || orig_global_plan.back().header.frame_id != current_goal_.header.frame_id) {
       // reset latching only if the goal changed
       latchedStopRotateController_.resetLatching();
     }
 
-    previous_goal_ = !orig_global_plan.empty() ? orig_global_plan.back() : geometry_msgs::PoseStamped();
+    current_goal_ = !orig_global_plan.empty() ? orig_global_plan.back() : geometry_msgs::PoseStamped();
 
     ROS_INFO("Got new plan");
     return dp_->setPlan(orig_global_plan);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -145,11 +145,13 @@ namespace dwa_local_planner {
       return false;
     }
 
+    if (orig_global_plan.empty() || orig_global_plan.back().pose != previous_goal.pose
+            || orig_global_plan.back().header.frame_id != previous_goal.header.frame_id) {
+      // reset latching only if the goal changed
+      latchedStopRotateController_.resetLatching();
+    }
+
     if (!orig_global_plan.empty()) {
-      if (orig_global_plan.back().pose != previous_goal.pose  || orig_global_plan.back().header.frame_id != previous_goal.header.frame_id) {
-        // reset latching only if the goal changed
-        latchedStopRotateController_.resetLatching();
-      }
       previous_goal = orig_global_plan.back();
     }
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -144,8 +144,14 @@ namespace dwa_local_planner {
       ROS_ERROR("This planner has not been initialized, please call initialize() before using this planner");
       return false;
     }
-    //when we get a new plan, we also want to clear any latch we may have on goal tolerances
-    latchedStopRotateController_.resetLatching();
+
+    if (!orig_global_plan.empty()) {
+      if (orig_global_plan.back().pose != previous_goal.pose  || orig_global_plan.back().header.frame_id != previous_goal.header.frame_id) {
+        // reset latching only if the goal changed
+        latchedStopRotateController_.resetLatching();
+      }
+      previous_goal = orig_global_plan.back();
+    }
 
     ROS_INFO("Got new plan");
     return dp_->setPlan(orig_global_plan);
@@ -163,6 +169,8 @@ namespace dwa_local_planner {
 
     if(latchedStopRotateController_.isGoalReached(&planner_util_, odom_helper_, current_pose_)) {
       ROS_INFO("Goal reached");
+      // reset latching such that the latching doesn't apply even if the same goal is targeted again
+      latchedStopRotateController_.resetLatching();
       return true;
     } else {
       return false;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -145,14 +145,14 @@ namespace dwa_local_planner {
       return false;
     }
 
-    if (orig_global_plan.empty() || orig_global_plan.back().pose != previous_goal.pose
-            || orig_global_plan.back().header.frame_id != previous_goal.header.frame_id) {
+    if (orig_global_plan.empty() || orig_global_plan.back().pose != previous_goal_.pose
+            || orig_global_plan.back().header.frame_id != previous_goal_.header.frame_id) {
       // reset latching only if the goal changed
       latchedStopRotateController_.resetLatching();
     }
 
     if (!orig_global_plan.empty()) {
-      previous_goal = orig_global_plan.back();
+      previous_goal_ = orig_global_plan.back();
     }
 
     ROS_INFO("Got new plan");

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -151,9 +151,7 @@ namespace dwa_local_planner {
       latchedStopRotateController_.resetLatching();
     }
 
-    if (!orig_global_plan.empty()) {
-      previous_goal_ = orig_global_plan.back();
-    }
+    previous_goal_ = !orig_global_plan.empty() ? orig_global_plan.back() : geometry_msgs::PoseStamped();
 
     ROS_INFO("Got new plan");
     return dp_->setPlan(orig_global_plan);


### PR DESCRIPTION
[Wrike task](https://www.wrike.com/open.htm?id=834235397)

Currently, setting the `latch_xy_goal_tolerance` parameter to `true` doesn't really have any effect if the global plan gets updated frequently. This can be tested by:
- sending a goal to the robot with its current position and opposite orientation
- while the robot is rotating, set a robot pose outside the goal tolerance

https://user-images.githubusercontent.com/4960007/153415961-8d5fdc29-4304-478c-9938-39fbaf890d00.mp4

Result before this PR: The robot stops rotating and starts moving around again.


------------------------------------------------------------------------------------------------------------------------------------------------------------


https://user-images.githubusercontent.com/4960007/153416139-45d7e0b3-0707-435f-ac4a-0aa665c250c8.mp4

Result with this PR: even though the injected pose is completely off (also orientation wise), the robot just rotates until the estimated orientation is aligned with the goal orientation: