### PR TITLE
Use latest tf available when transforming robot pose to global frame

### DIFF
--- a/base_local_planner/src/goal_functions.cpp
+++ b/base_local_planner/src/goal_functions.cpp
@@ -113,9 +113,10 @@ namespace base_local_planner {
       geometry_msgs::TransformStamped plan_to_global_transform = tf.lookupTransform(global_frame, ros::Time(),
           plan_pose.header.frame_id, plan_pose.header.stamp, plan_pose.header.frame_id, ros::Duration(0.5));
 
-      //let's get the pose of the robot in the frame of the plan
-      geometry_msgs::PoseStamped robot_pose;
-      tf.transform(global_pose, robot_pose, plan_pose.header.frame_id);
+      //let's get the pose of the robot in the frame of the plan using the latest transform available
+      geometry_msgs::PoseStamped robot_pose = global_pose;
+      robot_pose.header.stamp = ros::Time();
+      tf.transform(robot_pose, robot_pose, plan_pose.header.frame_id);
 
       //we'll discard points on the plan that are outside the local costmap
       double dist_threshold = std::max(costmap.getSizeInCellsX() * costmap.getResolution() / 2.0,


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=916749912

This allows us to set local_planner global_frame = odom (instead of map), as in sootballs

To test, set 
```
rosparam set /move_base_flex/local_costmap/global_frame odom
rosnode kill /move_base_flex
```
w/o the PR:
- [here](https://github.com/rapyuta-robotics/ros-navigation/blob/ed62d7554d544d69143c6c3ed1e82d94bfa9972d/dwa_local_planner/src/dwa_planner_ros.cpp#L274) we are getting the robot pose wrt odom frame, with a very recent timestamp
- [here](https://github.com/rapyuta-robotics/ros-navigation/blob/6b58447237b88e60525a8d0932ee4f729c308160/base_local_planner/src/goal_functions.cpp#L119) we are getting robot pose wrt map frame with that recent timestamp, which is not yet available for map --> odom tf

w/ the PR, we get the latest available robot pose wrt map frame, avoiding the problem

Related task explaining the root problem: https://www.wrike.com/open.htm?id=917570858