### PR TITLE
Scaled footprint visualisation

### DIFF
--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -63,10 +63,10 @@ public:
 
   void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed);
   void setFootprint(std::vector<geometry_msgs::Point> footprint_spec);
-  std::vector<geometry_msgs::Point> getScaledFootprint(Trajectory& traj);
+  std::vector<geometry_msgs::Point> getScaledFootprint(const Trajectory& traj) const;
 
   // helper functions, made static for easy unit testing
-  static double getScalingFactor(Trajectory &traj, double scaling_speed, double max_trans_vel);
+  static double getScalingFactor(const Trajectory &traj, double scaling_speed, double max_trans_vel);
   static double footprintCost(
       const double& x,
       const double& y,

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -63,6 +63,7 @@ public:
 
   void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed);
   void setFootprint(std::vector<geometry_msgs::Point> footprint_spec);
+  std::vector<geometry_msgs::Point> getScaledFootprint(Trajectory& traj);
 
   // helper functions, made static for easy unit testing
   static double getScalingFactor(Trajectory &traj, double scaling_speed, double max_trans_vel);

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -68,7 +68,7 @@ void ObstacleCostFunction::setFootprint(std::vector<geometry_msgs::Point> footpr
   footprint_spec_ = footprint_spec;
 }
 
-std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(Trajectory& traj) {
+std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(const Trajectory& traj) const {
   std::vector<geometry_msgs::Point> scaled_footprint = footprint_spec_;
   const double scale = getScalingFactor(traj, scaling_speed_, max_trans_vel_);
   if (scale != 0.0) {
@@ -123,7 +123,7 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
   return cost;
 }
 
-double ObstacleCostFunction::getScalingFactor(Trajectory &traj, double scaling_speed, double max_trans_vel) {
+double ObstacleCostFunction::getScalingFactor(const Trajectory &traj, double scaling_speed, double max_trans_vel) {
   double vmag = hypot(traj.xv_, traj.yv_);
 
   //if we're over a certain speed threshold, we'll scale the robot's

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -42,7 +42,7 @@
 
 namespace base_local_planner {
 
-ObstacleCostFunction::ObstacleCostFunction(costmap_2d::Costmap2D* costmap) 
+ObstacleCostFunction::ObstacleCostFunction(costmap_2d::Costmap2D* costmap)
     : costmap_(costmap), sum_scores_(false) {
   if (costmap != NULL) {
     world_model_ = new base_local_planner::CostmapModel(*costmap_);
@@ -68,21 +68,9 @@ void ObstacleCostFunction::setFootprint(std::vector<geometry_msgs::Point> footpr
   footprint_spec_ = footprint_spec;
 }
 
-bool ObstacleCostFunction::prepare() {
-  return true;
-}
-
-double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
-  double cost = 0;
-  double scale = getScalingFactor(traj, scaling_speed_, max_trans_vel_);
-  double px, py, pth;
-  if (footprint_spec_.size() == 0) {
-    // Bug, should never happen
-    ROS_ERROR("Footprint spec is empty, maybe missing call to setFootprint?");
-    return -9;
-  }
-
+std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(Trajectory& traj) {
   std::vector<geometry_msgs::Point> scaled_footprint = footprint_spec_;
+  const double scale = getScalingFactor(traj, scaling_speed_, max_trans_vel_);
   if (scale != 0.0) {
     const bool fwd = traj.xv_ > 0;
     const double forward_inflation = scale * max_forward_inflation_;
@@ -96,6 +84,23 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
       }
     }
   }
+  return scaled_footprint;
+}
+
+bool ObstacleCostFunction::prepare() {
+  return true;
+}
+
+double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
+  double cost = 0;
+  double px, py, pth;
+  if (footprint_spec_.size() == 0) {
+    // Bug, should never happen
+    ROS_ERROR("Footprint spec is empty, maybe missing call to setFootprint?");
+    return -9;
+  }
+
+  std::vector<geometry_msgs::Point> scaled_footprint = getScaledFootprint(traj);
 
    const unsigned int point_size = traj.getPointsSize();
   // ignore first trajectory point since it is the same for all trajectories,

--- a/dwa_local_planner/CMakeLists.txt
+++ b/dwa_local_planner/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED
             tf2
             tf2_geometry_msgs
             tf2_ros
+            visualization_msgs
         )
 
 find_package(Eigen3 REQUIRED)
@@ -49,6 +50,7 @@ catkin_package(
         roscpp
         tf2
         tf2_ros
+        visualization_msgs
 )
 
 add_library(dwa_local_planner src/dwa_planner.cpp src/dwa_planner_ros.cpp)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -151,7 +151,7 @@ namespace dwa_local_planner {
        * @param traj Trajectory to evaluate
        * @return Scaled footprint
        */
-      std::vector<geometry_msgs::Point> getScaledFootprint(base_local_planner::Trajectory &traj);
+      std::vector<geometry_msgs::Point> getScaledFootprint(const base_local_planner::Trajectory &traj) const;
 
     private:
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -73,7 +73,7 @@ namespace dwa_local_planner {
     public:
       /**
        * @brief  Constructor for the planner
-       * @param name The name of the planner 
+       * @param name The name of the planner
        * @param costmap_ros A pointer to the costmap instance the planner should use
        * @param global_frame the frame id of the tf frame to use
        */
@@ -98,8 +98,8 @@ namespace dwa_local_planner {
 
       /**
        * @brief Given the current position and velocity of the robot, find the best trajectory to exectue
-       * @param global_pose The current position of the robot 
-       * @param global_vel The current velocity of the robot 
+       * @param global_pose The current position of the robot
+       * @param global_vel The current velocity of the robot
        * @param drive_velocities The velocities to send to the robot base
        * @return The highest scoring trajectory. A cost >= 0 means the trajectory is legal to execute.
        */
@@ -117,7 +117,7 @@ namespace dwa_local_planner {
        * The obstacle cost function gets the footprint.
        * The path and goal cost functions get the global_plan
        * The alignment cost functions get a version of the global plan
-       *   that is modified based on the global_pose 
+       *   that is modified based on the global_pose
        */
       void updatePlanAndLocalCosts(const geometry_msgs::PoseStamped& global_pose,
           const std::vector<geometry_msgs::PoseStamped>& new_plan,
@@ -145,6 +145,13 @@ namespace dwa_local_planner {
        * sets new plan and resets state
        */
       bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
+
+      /**
+       * @brief Gets the footprint of the robot scaled by the given trajectory
+       * @param traj Trajectory to evaluate
+       * @return Scaled footprint
+       */
+      std::vector<geometry_msgs::Point> getScaledFootprint(base_local_planner::Trajectory &traj);
 
     private:
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -161,10 +161,12 @@ namespace dwa_local_planner {
 
       void publishGlobalPlan(std::vector<geometry_msgs::PoseStamped>& path);
 
+      void publishScaledFootprint(geometry_msgs::PoseStamped pose, base_local_planner::Trajectory &traj);
+
       tf2_ros::Buffer* tf_; ///< @brief Used for transforming point clouds
 
       // for visualisation, publishers of global and local plan
-      ros::Publisher g_plan_pub_, l_plan_pub_;
+      ros::Publisher g_plan_pub_, l_plan_pub_, scaled_fp_pub_;
 
       base_local_planner::LocalPlannerUtil planner_util_;
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -161,7 +161,7 @@ namespace dwa_local_planner {
 
       void publishGlobalPlan(std::vector<geometry_msgs::PoseStamped>& path);
 
-      void publishScaledFootprint(geometry_msgs::PoseStamped pose, base_local_planner::Trajectory &traj);
+      void publishScaledFootprint(const geometry_msgs::PoseStamped& pose, const base_local_planner::Trajectory &traj) const;
 
       tf2_ros::Buffer* tf_; ///< @brief Used for transforming point clouds
 

--- a/dwa_local_planner/package.xml
+++ b/dwa_local_planner/package.xml
@@ -43,11 +43,10 @@
     <depend>tf2</depend>
     <depend>tf2_geometry_msgs</depend>
     <depend>tf2_ros</depend>
+    <depend>visualization_msgs</depend>
 
     <export>
         <mbf_costmap_core plugin="${prefix}/blp_plugin.xml" />
     </export>
 
 </package>
-
-

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -219,7 +219,7 @@ namespace dwa_local_planner {
     return planner_util_->setPlan(orig_global_plan);
   }
 
-  std::vector<geometry_msgs::Point> DWAPlanner::getScaledFootprint(base_local_planner::Trajectory &traj) {
+  std::vector<geometry_msgs::Point> DWAPlanner::getScaledFootprint(const base_local_planner::Trajectory &traj) const {
     return obstacle_costs_.getScaledFootprint(traj);
   }
 

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -79,7 +79,7 @@ namespace dwa_local_planner {
     forward_point_distance_ = config.forward_point_distance;
     goal_front_costs_.setXShift(forward_point_distance_);
     alignment_costs_.setXShift(forward_point_distance_);
- 
+
     // obstacle costs can vary due to scaling footprint feature
     obstacle_costs_.setParams(config.max_vel_trans, config.max_forward_inflation, config.max_sideward_inflation, config.scaling_speed);
 
@@ -92,29 +92,29 @@ namespace dwa_local_planner {
     vx_samp = config.vx_samples;
     vy_samp = config.vy_samples;
     vth_samp = config.vth_samples;
- 
+
     if (vx_samp <= 0) {
       ROS_WARN("You've specified that you don't want any samples in the x dimension. We'll at least assume that you want to sample one value... so we're going to set vx_samples to 1 instead");
       vx_samp = 1;
       config.vx_samples = vx_samp;
     }
- 
+
     if (vy_samp <= 0) {
       ROS_WARN("You've specified that you don't want any samples in the y dimension. We'll at least assume that you want to sample one value... so we're going to set vy_samples to 1 instead");
       vy_samp = 1;
       config.vy_samples = vy_samp;
     }
- 
+
     if (vth_samp <= 0) {
       ROS_WARN("You've specified that you don't want any samples in the th dimension. We'll at least assume that you want to sample one value... so we're going to set vth_samples to 1 instead");
       vth_samp = 1;
       config.vth_samples = vth_samp;
     }
- 
+
     vsamples_[0] = vx_samp;
     vsamples_[1] = vy_samp;
     vsamples_[2] = vth_samp;
- 
+
 
   }
 
@@ -217,6 +217,10 @@ namespace dwa_local_planner {
       oscillation_costs_.resetOscillationFlags();
     }
     return planner_util_->setPlan(orig_global_plan);
+  }
+
+  std::vector<geometry_msgs::Point> DWAPlanner::getScaledFootprint(base_local_planner::Trajectory &traj) {
+    return obstacle_costs_.getScaledFootprint(traj);
   }
 
   /**

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -45,6 +45,7 @@
 
 #include <base_local_planner/goal_functions.h>
 #include <nav_msgs/Path.h>
+#include <visualization_msgs/Marker.h>
 #include <tf2/utils.h>
 
 #include <nav_core/parameter_magic.h>
@@ -105,7 +106,7 @@ namespace dwa_local_planner {
       ros::NodeHandle private_nh("~/" + name);
       g_plan_pub_ = private_nh.advertise<nav_msgs::Path>("global_plan", 1);
       l_plan_pub_ = private_nh.advertise<nav_msgs::Path>("local_plan", 1);
-      scaled_fp_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>("scaled_footprint", 1);
+      scaled_fp_pub_ = private_nh.advertise<visualization_msgs::Marker>("scaled_footprint", 1);
       tf_ = tf;
       costmap_ros_ = costmap_ros;
       costmap_ros_->getRobotPose(current_pose_);
@@ -190,11 +191,17 @@ namespace dwa_local_planner {
   }
 
   void DWAPlannerROS::publishScaledFootprint(geometry_msgs::PoseStamped pose, base_local_planner::Trajectory &traj) {
-    geometry_msgs::PolygonStamped footprint;
-    footprint.header.frame_id = pose.header.frame_id;
-    footprint.header.stamp = ros::Time::now();
-    costmap_2d::transformFootprint(pose.pose.position.x, pose.pose.position.y, tf2::getYaw(pose.pose.orientation), dp_->getScaledFootprint(traj), footprint);
-    scaled_fp_pub_.publish(footprint);
+    visualization_msgs::Marker marker;
+    marker.header.frame_id = pose.header.frame_id;
+    marker.header.stamp = ros::Time::now();
+    marker.lifetime = ros::Duration(2 * dp_->getSimPeriod()); // double sim period to avoid flickering
+    marker.type = visualization_msgs::Marker::LINE_STRIP;
+    marker.pose = pose.pose;
+    marker.scale.x = 0.01;
+    marker.color.g = marker.color.a = 1.0;
+    marker.points = dp_->getScaledFootprint(traj);
+    marker.points.push_back(marker.points.front()); // close the polygon
+    scaled_fp_pub_.publish(marker);
   }
 
   DWAPlannerROS::~DWAPlannerROS(){

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -194,11 +194,11 @@ namespace dwa_local_planner {
     visualization_msgs::Marker marker;
     marker.header.frame_id = pose.header.frame_id;
     marker.header.stamp = ros::Time::now();
-    marker.lifetime = ros::Duration(2 * dp_->getSimPeriod()); // double sim period to avoid flickering
+    marker.lifetime = ros::Duration(2 * dp_->getSimPeriod()); // double the sim period to avoid flickering
     marker.type = visualization_msgs::Marker::LINE_STRIP;
     marker.pose = pose.pose;
     marker.scale.x = 0.01;
-    marker.color.g = marker.color.a = 1.0;
+    marker.color.g = marker.color.a = 1.0; // green
     marker.points = dp_->getScaledFootprint(traj);
     marker.points.push_back(marker.points.front()); // close the polygon
     scaled_fp_pub_.publish(marker);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -105,6 +105,7 @@ namespace dwa_local_planner {
       ros::NodeHandle private_nh("~/" + name);
       g_plan_pub_ = private_nh.advertise<nav_msgs::Path>("global_plan", 1);
       l_plan_pub_ = private_nh.advertise<nav_msgs::Path>("local_plan", 1);
+      scaled_fp_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>("scaled_footprint", 1);
       tf_ = tf;
       costmap_ros_ = costmap_ros;
       costmap_ros_->getRobotPose(current_pose_);
@@ -121,7 +122,7 @@ namespace dwa_local_planner {
       {
         odom_helper_.setOdomTopic( odom_topic_ );
       }
-      
+
       initialized_ = true;
 
       // Warn about deprecated parameters -- remove this block in N-turtle
@@ -140,7 +141,7 @@ namespace dwa_local_planner {
       ROS_WARN("This planner has already been initialized, doing nothing.");
     }
   }
-  
+
   bool DWAPlannerROS::setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan) {
     if (! isInitialized()) {
       ROS_ERROR("This planner has not been initialized, please call initialize() before using this planner");
@@ -188,6 +189,14 @@ namespace dwa_local_planner {
     base_local_planner::publishPlan(path, g_plan_pub_);
   }
 
+  void DWAPlannerROS::publishScaledFootprint(geometry_msgs::PoseStamped pose, base_local_planner::Trajectory &traj) {
+    geometry_msgs::PolygonStamped footprint;
+    footprint.header.frame_id = pose.header.frame_id;
+    footprint.header.stamp = ros::Time::now();
+    costmap_2d::transformFootprint(pose.pose.position.x, pose.pose.position.y, tf2::getYaw(pose.pose.orientation), dp_->getScaledFootprint(traj), footprint);
+    scaled_fp_pub_.publish(footprint);
+  }
+
   DWAPlannerROS::~DWAPlannerROS(){
     //make sure to clean things up
     delete dsrv_;
@@ -216,7 +225,7 @@ namespace dwa_local_planner {
     //compute what trajectory to drive along
     geometry_msgs::PoseStamped drive_cmds;
     drive_cmds.header.frame_id = costmap_ros_->getBaseFrameID();
-    
+
     // call with updated footprint
     base_local_planner::Trajectory path = dp_->findBestPath(global_pose, robot_vel, drive_cmds);
     //ROS_ERROR("Best: %.2f, %.2f, %.2f, %.2f", path.xv_, path.yv_, path.thetav_, path.cost_);
@@ -244,7 +253,7 @@ namespace dwa_local_planner {
       return mbf_msgs::ExePathResult::NO_VALID_CMD;
     }
 
-    ROS_DEBUG_NAMED("dwa_local_planner", "A valid velocity command of (%.2f, %.2f, %.2f) was found for this cycle.", 
+    ROS_DEBUG_NAMED("dwa_local_planner", "A valid velocity command of (%.2f, %.2f, %.2f) was found for this cycle.",
                     cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z);
     cmd_vel.header.stamp = ros::Time::now();
 
@@ -266,7 +275,7 @@ namespace dwa_local_planner {
     }
 
     //publish information to the visualizer
-
+    publishScaledFootprint(global_pose, path);
     publishLocalPlan(local_plan);
     return mbf_msgs::ExePathResult::SUCCESS;
   }

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -190,7 +190,7 @@ namespace dwa_local_planner {
     base_local_planner::publishPlan(path, g_plan_pub_);
   }
 
-  void DWAPlannerROS::publishScaledFootprint(geometry_msgs::PoseStamped pose, base_local_planner::Trajectory &traj) {
+  void DWAPlannerROS::publishScaledFootprint(const geometry_msgs::PoseStamped& pose, const base_local_planner::Trajectory &traj) const {
     visualization_msgs::Marker marker;
     marker.header.frame_id = pose.header.frame_id;
     marker.header.stamp = ros::Time::now();


### PR DESCRIPTION
## Description

Added visualisation for the scaled footprint to help with debugging navigation issues.
Works in the same way as TEB footprint model -- simply add the `~/scaled_footprint` topic to rviz.

**Bonus:** some whitespace cleaning performed automatically by vscode.

## Demo

(_**orange:** regular footprint, **green:** scaled footprint_)

https://user-images.githubusercontent.com/15384781/179691792-a5687491-743c-4496-aab8-c9ad4f8cbf41.mp4