### PR TITLE
Obstacle cost based only on center point of robot instead of footprint

### DIFF
--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -61,7 +61,7 @@ public:
 
   void setSumScores(bool score_sums){ sum_scores_=score_sums; }
 
-  void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed, bool occdist_use_footprint);
+  void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed, bool occdist_use_footprint = true);
   void setFootprint(std::vector<geometry_msgs::Point> footprint_spec);
   std::vector<geometry_msgs::Point> getScaledFootprint(const Trajectory& traj) const;
 

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -61,13 +61,13 @@ public:
 
   void setSumScores(bool score_sums){ sum_scores_=score_sums; }
 
-  void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed);
+  void setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed, bool occdist_use_footprint);
   void setFootprint(std::vector<geometry_msgs::Point> footprint_spec);
   std::vector<geometry_msgs::Point> getScaledFootprint(const Trajectory& traj) const;
 
   // helper functions, made static for easy unit testing
   static double getScalingFactor(const Trajectory &traj, double scaling_speed, double max_trans_vel);
-  static double footprintCost(
+  double footprintCost(
       const double& x,
       const double& y,
       const double& th,
@@ -86,6 +86,7 @@ private:
 
   ros::Subscriber sideward_inflation_scale_sub_;
   std::atomic<double> sideward_inflation_scale_;
+  bool occdist_use_footprint_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -160,7 +160,7 @@ double ObstacleCostFunction::footprintCost (
     return -7.0;
   }
 
-  double occ_cost = std::max(std::max(0.0, footprint_cost), double(costmap->getCost(cell_x, cell_y)));
+  double occ_cost = double(costmap->getCost(cell_x, cell_y));
 
   return occ_cost;
 }

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -62,12 +62,13 @@ ObstacleCostFunction::~ObstacleCostFunction() {
 }
 
 
-void ObstacleCostFunction::setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed) {
+void ObstacleCostFunction::setParams(double max_trans_vel, double max_forward_inflation, double max_sideward_inflation, double scaling_speed, bool occdist_use_footprint) {
   // TODO: move this to prepare if possible
   max_trans_vel_ = max_trans_vel;
   max_forward_inflation_ = max_forward_inflation;
   max_sideward_inflation_ = max_sideward_inflation;
   scaling_speed_ = scaling_speed;
+  occdist_use_footprint_ = occdist_use_footprint;
 }
 
 void ObstacleCostFunction::setFootprint(std::vector<geometry_msgs::Point> footprint_spec) {
@@ -161,6 +162,10 @@ double ObstacleCostFunction::footprintCost (
   }
 
   double occ_cost = double(costmap->getCost(cell_x, cell_y));
+  if (occdist_use_footprint_)
+  {
+    occ_cost = std::max(std::max(0.0, footprint_cost), occ_cost);
+  }
 
   return occ_cost;
 }

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -28,7 +28,7 @@ gen.add("forward_point_distance", double_t, 0, "The distance from the center poi
 gen.add("scaling_speed", double_t, 0, "The absolute value of the velocity at which to start scaling the robot's footprint, in m/s", 0.25, 0)
 gen.add("max_forward_inflation", double_t, 0, "The maximum length the robot's footprint is extended forward by", 0.2, 0)
 gen.add("max_sideward_inflation", double_t, 0, "The maximum length the robot's footprint is extended sidewards by", 0.2, 0)
-gen.add("occdist_use_footprint", bool_t, 0, "Use footprint cost when computing the obstacle distance part of the cost function", False)
+gen.add("occdist_use_footprint", bool_t, 0, "Use footprint cost when computing the obstacle distance part of the cost function. If set to false, will use the cost at the robot pose", True)
 
 gen.add("vx_samples", int_t, 0, "The number of samples to use when exploring the x velocity space", 3, 1)
 gen.add("vy_samples", int_t, 0, "The number of samples to use when exploring the y velocity space", 10, 1)

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -28,6 +28,7 @@ gen.add("forward_point_distance", double_t, 0, "The distance from the center poi
 gen.add("scaling_speed", double_t, 0, "The absolute value of the velocity at which to start scaling the robot's footprint, in m/s", 0.25, 0)
 gen.add("max_forward_inflation", double_t, 0, "The maximum length the robot's footprint is extended forward by", 0.2, 0)
 gen.add("max_sideward_inflation", double_t, 0, "The maximum length the robot's footprint is extended sidewards by", 0.2, 0)
+gen.add("occdist_use_footprint", bool_t, 0, "Use footprint cost when computing the obstacle distance part of the cost function", False)
 
 gen.add("vx_samples", int_t, 0, "The number of samples to use when exploring the x velocity space", 3, 1)
 gen.add("vy_samples", int_t, 0, "The number of samples to use when exploring the y velocity space", 10, 1)

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -81,7 +81,7 @@ namespace dwa_local_planner {
     alignment_costs_.setXShift(forward_point_distance_);
 
     // obstacle costs can vary due to scaling footprint feature
-    obstacle_costs_.setParams(config.max_vel_trans, config.max_forward_inflation, config.max_sideward_inflation, config.scaling_speed);
+    obstacle_costs_.setParams(config.max_vel_trans, config.max_forward_inflation, config.max_sideward_inflation, config.scaling_speed, config.occdist_use_footprint);
 
     twirling_costs_.setScale(config.twirling_scale);
 


### PR DESCRIPTION
## Description

Currently all trajectories for which the footprint intersects with an `INSCRIBED` cost have the same obstacle cost (i.e. all trajectories for which the closest obstacle to the footprint is in [0, inscribed_radius] all have the same cost)
This PR changes it so that trajectories bringing the robot away from obstacles are rewarded.
Can toggle between new and old behavior by setting the dynamic reconfigure param `occdist_use_footprint`.

Tested in simulation and real-robot.
The change sounds good in theory, but in practice didn't notice any difference in behavior.