### PR TITLE
fix cmake warning

### DIFF
--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -187,5 +187,6 @@ bool RotateRecovery::runBehavior(const double rotation_angle)
 
     r.sleep();
   }
+  return false;
 }
 };  // namespace rotate_recovery


### PR DESCRIPTION
Fix cmake warning for `warning: control reaches end of non-void function [-Wreturn-type]`
