### PR TITLE
Change path alignment critic

### DIFF
--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -6,6 +6,7 @@
 namespace base_local_planner {
 
 constexpr double MAX_ANGLE_ERROR = 0.8;
+constexpr double PREDICTION_TIME = 1.5;
 
 class AlignWithPathFunction : public base_local_planner::TrajectoryCostFunction {
 public:

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -12,8 +12,6 @@ class AlignWithPathFunction : public base_local_planner::TrajectoryCostFunction 
 public:
   AlignWithPathFunction();
 
-  void setMaxVelTheta(double max_vel_theta);
-
   void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose);
 
   bool prepare();

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -26,7 +26,6 @@ public:
 
 private:
   double current_yaw_diff_;
-  double max_vel_theta_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -19,6 +19,10 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
+  bool isTurningRequired() const {
+    return std::abs(current_yaw_diff_) > MAX_ANGLE_ERROR;
+  }
+
 private:
   double current_yaw_diff_;
   double max_vel_theta_;

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -11,18 +11,17 @@ class AlignWithPathFunction : public base_local_planner::TrajectoryCostFunction 
 public:
   AlignWithPathFunction();
 
+  void setMaxVelTheta(double max_vel_theta);
+
   void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose);
 
   bool prepare();
 
   double scoreTrajectory(Trajectory &traj);
 
-  bool isTurningRequired() const {
-    return std::abs(current_yaw_diff_) > MAX_ANGLE_ERROR;
-  }
-
 private:
   double current_yaw_diff_;
+  double max_vel_theta_;
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -1,46 +1,42 @@
 #include <base_local_planner/align_with_path_function.h>
-#include <math.h> /* atan2 */
+#include <math.h>       /* atan2 */
 #include <angles/angles.h>
 
-namespace base_local_planner
-{
+namespace base_local_planner {
 
 constexpr double MIN_ROT_SPEED = 0.1;
 constexpr double PENALTY_COST = 1e6;
 
-AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0)
-{
-}
+AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0) {}
 
-void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta)
-{
+void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta) {
   max_vel_theta_ = max_vel_theta;
 }
 
 void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses,
-                                           const geometry_msgs::PoseStamped& global_pose)
-{
+                                           const geometry_msgs::PoseStamped& global_pose) {
   current_yaw_diff_ = 0;
   const int num_points = target_poses.size();
-  if (num_points <= 0)
-  {
+  if (num_points <= 0) {
     return;
   }
   // todo: decide which point to pick
-  geometry_msgs::PoseStamped path_node = *(target_poses.begin() + std::min(3, num_points - 1));
-  const double path_yaw = 2 * atan2(path_node.pose.orientation.z, path_node.pose.orientation.w);
+  geometry_msgs::PoseStamped path_node = *(target_poses.begin() + std::min(3, num_points-1));
+  const double path_yaw = 2 * atan2 (path_node.pose.orientation.z, path_node.pose.orientation.w);
 
   const double current_yaw = 2 * atan2(global_pose.pose.orientation.z, global_pose.pose.orientation.w);
   current_yaw_diff_ = angles::normalize_angle(path_yaw - current_yaw);
 }
 
-bool AlignWithPathFunction::prepare()
-{
+bool AlignWithPathFunction::prepare() {
   return true;
 }
 
-double AlignWithPathFunction::scoreTrajectory(Trajectory& traj)
-{
+double AlignWithPathFunction::scoreTrajectory(Trajectory& traj) {
+  if (!isTurningRequired()) {
+    return 0;
+  }
+
   // make spin velocity proportional to delta yaw
   // spin fast when far away from target yaw and slow down once we get closer
   return std::abs(std::abs(current_yaw_diff_) / M_PI - std::abs(traj.thetav_) / (max_vel_theta_ + 1e-3));

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -13,15 +13,14 @@ void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta) {
   max_vel_theta_ = max_vel_theta;
 }
 
-void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses,
-                                           const geometry_msgs::PoseStamped& global_pose) {
+void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose) {
   current_yaw_diff_ = 0;
   const int num_points = target_poses.size();
   if (num_points <= 0) {
     return;
   }
   // todo: decide which point to pick
-  geometry_msgs::PoseStamped path_node = *(target_poses.begin() + std::min(3, num_points-1));
+  geometry_msgs::PoseStamped path_node =  *(target_poses.begin() + std::min(3, num_points-1));
   const double path_yaw = 2 * atan2 (path_node.pose.orientation.z, path_node.pose.orientation.w);
 
   const double current_yaw = 2 * atan2(global_pose.pose.orientation.z, global_pose.pose.orientation.w);
@@ -32,7 +31,7 @@ bool AlignWithPathFunction::prepare() {
   return true;
 }
 
-double AlignWithPathFunction::scoreTrajectory(Trajectory& traj) {
+double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {
   if (!isTurningRequired()) {
     return 0;
   }

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -7,7 +7,12 @@ namespace base_local_planner {
 constexpr double MIN_ROT_SPEED = 0.1;
 constexpr double PENALTY_COST = 1e6;
 
-AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0) {}
+AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0) {}
+
+void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta)
+{
+  max_vel_theta_ = max_vel_theta;
+}
 
 void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose) {
   current_yaw_diff_ = 0;
@@ -28,18 +33,9 @@ bool AlignWithPathFunction::prepare() {
 }
 
 double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {
-  if (!isTurningRequired()) {
-    return 0;
-  }
-
-  // if angle off by more than MAX_ANGLE_ERROR, force to rotate towards path with more than MIN_ROT_SPEED
-  if (current_yaw_diff_ > 0 && traj.thetav_ < MIN_ROT_SPEED) {
-    return PENALTY_COST;
-  }
-  if (current_yaw_diff_ < 0 && traj.thetav_ > -MIN_ROT_SPEED) {
-    return PENALTY_COST;
-  }
-  return 0;
+  // make spin velocity proportional to delta yaw
+  // spin fast when far away from target yaw and slow down once we get closer
+  return std::abs(std::abs(current_yaw_diff_) / M_PI - std::abs(traj.thetav_) / max_vel_theta_);
 }
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -1,41 +1,49 @@
 #include <base_local_planner/align_with_path_function.h>
-#include <math.h>       /* atan2 */
+#include <math.h> /* atan2 */
 #include <angles/angles.h>
 
-namespace base_local_planner {
+namespace base_local_planner
+{
 
 constexpr double MIN_ROT_SPEED = 0.1;
 constexpr double PENALTY_COST = 1e6;
 
-AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0) {}
+AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0)
+{
+}
 
 void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta)
 {
   max_vel_theta_ = max_vel_theta;
 }
 
-void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose) {
+void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses,
+                                           const geometry_msgs::PoseStamped& global_pose)
+{
   current_yaw_diff_ = 0;
   const int num_points = target_poses.size();
-  if (num_points <= 0) {
+  if (num_points <= 0)
+  {
     return;
   }
   // todo: decide which point to pick
-  geometry_msgs::PoseStamped path_node =  *(target_poses.begin() + std::min(3, num_points-1));
-  const double path_yaw = 2 * atan2 (path_node.pose.orientation.z, path_node.pose.orientation.w);
+  geometry_msgs::PoseStamped path_node = *(target_poses.begin() + std::min(3, num_points - 1));
+  const double path_yaw = 2 * atan2(path_node.pose.orientation.z, path_node.pose.orientation.w);
 
   const double current_yaw = 2 * atan2(global_pose.pose.orientation.z, global_pose.pose.orientation.w);
   current_yaw_diff_ = angles::normalize_angle(path_yaw - current_yaw);
 }
 
-bool AlignWithPathFunction::prepare() {
+bool AlignWithPathFunction::prepare()
+{
   return true;
 }
 
-double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {
+double AlignWithPathFunction::scoreTrajectory(Trajectory& traj)
+{
   // make spin velocity proportional to delta yaw
   // spin fast when far away from target yaw and slow down once we get closer
-  return std::abs(std::abs(current_yaw_diff_) / M_PI - std::abs(traj.thetav_) / max_vel_theta_);
+  return std::abs(std::abs(current_yaw_diff_) / M_PI - std::abs(traj.thetav_) / (max_vel_theta_ + 1e-3));
 }
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -7,11 +7,7 @@ namespace base_local_planner {
 constexpr double MIN_ROT_SPEED = 0.1;
 constexpr double PENALTY_COST = 1e6;
 
-AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0), max_vel_theta_(0) {}
-
-void AlignWithPathFunction::setMaxVelTheta(double max_vel_theta) {
-  max_vel_theta_ = max_vel_theta;
-}
+AlignWithPathFunction::AlignWithPathFunction() : current_yaw_diff_(0) {}
 
 void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose) {
   current_yaw_diff_ = 0;

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -36,9 +36,7 @@ double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {
     return 0;
   }
 
-  // make spin velocity proportional to delta yaw
-  // spin fast when far away from target yaw and slow down once we get closer
-  return std::abs(std::abs(current_yaw_diff_) / M_PI - std::abs(traj.thetav_) / (max_vel_theta_ + 1e-3));
+  return std::abs(angles::normalize_angle(current_yaw_diff_ - traj.thetav_ * PREDICTION_TIME));
 }
 
 } /* namespace base_local_planner */

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -327,7 +327,7 @@ namespace dwa_local_planner {
     goal_front_costs_.setTargetPoses(front_global_plan);
 
     constexpr double MIN_GOAL_DIST_SQ = 0.7;
-    if (sq_dist > MIN_GOAL_DIST_SQ) {
+    if (sq_dist > MIN_GOAL_DIST_SQ && path_align_costs_.isTurningRequired()) {
       // enable turning penalty
       path_align_costs_.setScale(1.0);
       // disable goal cost during turning because turning won't move the robot closer to the goal

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,6 +85,8 @@ namespace dwa_local_planner {
 
     twirling_costs_.setScale(config.twirling_scale);
 
+    path_align_costs_.setMaxVelTheta(config.max_vel_theta);
+
     backwardvel_scale_ = 1.2 * config.sim_time * (config.path_distance_bias + config.goal_distance_bias);
     prefer_forward_costs_.setScale(backwardvel_scale_);
 
@@ -325,7 +327,7 @@ namespace dwa_local_planner {
     goal_front_costs_.setTargetPoses(front_global_plan);
 
     constexpr double MIN_GOAL_DIST_SQ = 0.7;
-    if (sq_dist > MIN_GOAL_DIST_SQ && path_align_costs_.isTurningRequired()) {
+    if (sq_dist > MIN_GOAL_DIST_SQ) {
       // enable turning penalty
       path_align_costs_.setScale(1.0);
       // disable goal cost during turning because turning won't move the robot closer to the goal

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,8 +85,6 @@ namespace dwa_local_planner {
 
     twirling_costs_.setScale(config.twirling_scale);
 
-    path_align_costs_.setMaxVelTheta(config.max_vel_theta);
-
     backwardvel_scale_ = 1.2 * config.sim_time * (config.path_distance_bias + config.goal_distance_bias);
     prefer_forward_costs_.setScale(backwardvel_scale_);
 


### PR DESCRIPTION
## Description

Change the logic of the path alignment critic to make the angular velocity proportional to the angular difference.
This fixes the slow spin that happened sometimes when doing a 180º turn.
Also fixes the overshoot that happened sometimes.
Tested in simulation and in the real robot.