### PR TITLE
fix turn overshoot

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -154,6 +154,8 @@ namespace dwa_local_planner {
       std::vector<geometry_msgs::Point> getScaledFootprint(const base_local_planner::Trajectory &traj) const;
 
     private:
+      /// @todo: consider exposing this as a parameter
+      static constexpr double MIN_GOAL_DIST_SQ = 0.7; ///< @brief Squared distance from the goal outside which the robot is encouraged to turn towards the path orientation, and within which the forward_point_distance is reduced to prevent the robot's nose from having to enter cells with cost >= INSCRIBED in order to reach the goal.
 
       base_local_planner::LocalPlannerUtil *planner_util_;
 

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -291,12 +291,13 @@ namespace dwa_local_planner {
     double angle_to_goal = atan2(goal_pose.pose.position.y - pos[1], goal_pose.pose.position.x - pos[0]);
 
     constexpr double MIN_GOAL_DIST_SQ = 0.7;
-    // reduce crop forward_point_distance such that the robot can reach the goal pose
-    // without its nose entering space considered as occupied by obstacles
+
     double forward_point_distance = forward_point_distance_;
     const auto cos_angle_to_goal = cos(angle_to_goal);
     const auto sin_angle_to_goal = sin(angle_to_goal);
     if (sq_dist < MIN_GOAL_DIST_SQ) {
+      // when close to the goal, reduce forward_point_distance such that the robot can reach the goal pose
+      // without its nose entering space considered as occupied by obstacles
       forward_point_distance = 0;
       const int res = 10;
       for (int i = 1; i <= res; ++i) {

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -290,8 +290,6 @@ namespace dwa_local_planner {
     std::vector<geometry_msgs::PoseStamped> front_global_plan = global_plan_;
     double angle_to_goal = atan2(goal_pose.pose.position.y - pos[1], goal_pose.pose.position.x - pos[0]);
 
-    constexpr double MIN_GOAL_DIST_SQ = 0.7;
-
     double forward_point_distance = forward_point_distance_;
     const auto cos_angle_to_goal = cos(angle_to_goal);
     const auto sin_angle_to_goal = sin(angle_to_goal);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -299,9 +299,9 @@ namespace dwa_local_planner {
       // when close to the goal, reduce forward_point_distance such that the robot can reach the goal pose
       // without its nose entering space considered as occupied by obstacles
       forward_point_distance = 0;
-      const int res = 10;
-      for (int i = 1; i <= res; ++i) {
-          const double new_forward_point_distance = i * 1.0/res * forward_point_distance_;
+      const float num_steps = std::ceil(forward_point_distance_ / planner_util_->getCostmap()->getResolution());
+      for (int i = 1; i <= num_steps; ++i) {
+          const double new_forward_point_distance = (i / num_steps) * forward_point_distance_;
           const double x = front_global_plan.back().pose.position.x +
               std::abs(new_forward_point_distance) * cos_angle_to_goal;
           const double y = front_global_plan.back().pose.position.y +


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=957371863

Summary of the issue:
- the DWA planner uses a virtual point in front of the robot (`forward_point_distance` [m]) to align the robot with the goal / path
- so at the goal, this virtual point is expected to be `forward_point_distance` behind the goal, so the reference point for goal alignment is set  `forward_point_distance` behind the goal ([here](https://github.com/ros-planning/navigation/blob/47c9c629fc93e6c6bbcd3109eb2d5b55efce400d/dwa_local_planner/src/dwa_planner.cpp#L271-L276))
- however, this causes issues (in the upstream version) if the goal is too close to an obstacle, which can result in this reference point to be in INSCRIBED region ([which is treated as obstacles by underlying map_grid](https://github.com/ros-planning/navigation/blob/47c9c629fc93e6c6bbcd3109eb2d5b55efce400d/base_local_planner/src/map_grid.cpp#L109-L112)), in which case another point on the path will be used internally as the reference point. This is a problem though because if the robot is at the goal, the point `forward_point_distance` ahead of the robot is within INSCRIBED, and trajectories for which this happen are rejected.
- to fix this, I made a modification long time ago that checks how far ahead this virtual point can be such that it is still in the free space (cost < INSCRIBED).
- however, this fix didn't check how far away from the goal the robot is; if the goal is very far away from the robot, it is outside the costmap, so this logic would set `forward_point_distance` to 0.
- so the fix in this PR is to only run this `forward_point_distance` adjustment logic once the robot gets close to the goal