### PR TITLE
Fixed bug causing global planner to plan to wrong cell

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -205,8 +205,8 @@ bool GlobalPlanner::worldToMap(double wx, double wy, double& mx, double& my) {
     if (wx < origin_x || wy < origin_y)
         return false;
 
-    mx = (wx - origin_x) / resolution - convert_offset_;
-    my = (wy - origin_y) / resolution - convert_offset_;
+    mx = (wx - origin_x) / resolution;
+    my = (wy - origin_y) / resolution;
 
     if (mx < costmap_->getSizeInCellsX() && my < costmap_->getSizeInCellsY())
         return true;


### PR DESCRIPTION
## Description

Fixed a bug that was causing the global planner to compute paths to the wrong cell.
This allowed the global planner to return paths that were in collision.
You can see in the picture below how the global plan clearly ends inside the inscribed region of the costmap (i.e. collision!)

![image](https://user-images.githubusercontent.com/15384781/193736975-c90dc30f-df78-4f48-a230-0085d7c3935c.png)

When the param `old_navfn_behavior` was set to `false`, the `worldToMap` function was subtracting `0.5` from the resulting cell coordinates, which is wrong. Although it makes sense to **add** `0.5` when converting from map to world (in order to return the center of the cell rather than the corner), the opposite is not true!

## Example

Assume a 1D costmap filled with random costs.
Its size is `4`, going from real world coordinate `0.0` to `1.0`.
The resolution is `0.25`.
The origin is at `0.0`.
Lethal cost is `253`.

| 0 | 100 | 200 | 253 |
|---|-----|-----|-----|

The goal is at world coord `0.8`.
This clearly corresponds to the last cell in the costmap with index `3`, which has a lethal cost and therefore not a reachable goal.
However, the current `worldToMap` function would return `2.7` instead of the expected `3.2`:
```cpp
mx = (wx - origin_x) / resolution - convert_offset_ = 0.8 / 0.25 - 0.5 = 3.2 - 0.5 = 2.7
```

This is obviously incorrect. So, later on when we try to read the cost of the goal cell (i.e. by casting to `int` the map coord we obtained above) we would actually be reading the cost of the cell of index `2` instead of `3`! 

So, even though the goal is actually impossible to reach (lethal cost), we will generate a plan that goes until the cell index `2`, which is a valid goal (cost lower than lethal!)

The reason why we don't notice the plan is wrong is because the actual goal position is always appended to the end of the plan:

https://github.com/rapyuta-robotics/ros-navigation/blob/11b5c2034e1f9cbe9512a22c3dfa389e478b04e8/global_planner/src/planner_core.cpp#L303-L307

So even though we actually only planned until cell `2`, we will output a plan that goes until cell `3` -- even though cell `3` might be lethal!