### PR TITLE
dont consider far away goal in obstacle as local goal

### DIFF
--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -218,7 +218,7 @@ namespace base_local_planner{
     std::vector<geometry_msgs::PoseStamped> adjusted_global_plan;
     adjustPlanResolution(global_plan, adjusted_global_plan, costmap.getResolution());
 
-    auto dist_squared_to_front = [&adjusted_global_plan](const double x, const double y) {
+    auto dist_squared_to_start = [&adjusted_global_plan](const double x, const double y) {
       const double dx = x - adjusted_global_plan.front().pose.position.x;
       const double dy = y - adjusted_global_plan.front().pose.position.y;
       return dx * dx + dy * dy;
@@ -246,10 +246,9 @@ namespace base_local_planner{
       double g_x = adjusted_global_plan[i].pose.position.x;
       double g_y = adjusted_global_plan[i].pose.position.y;
       unsigned int map_x, map_y;
-      reached_point_away_from_start = reached_point_away_from_start || dist_squared_to_front(g_x, g_y) > 1;
+      reached_point_away_from_start = reached_point_away_from_start || dist_squared_to_start(g_x, g_y) > 1;
       if (costmap.worldToMap(g_x, g_y, map_x, map_y) && costmap.getCost(map_x, map_y) != costmap_2d::NO_INFORMATION) {
-		const bool in_obstacle = costmap.getCost(map_x, map_y) == costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
-		    costmap.getCost(map_x, map_y) == costmap_2d::LETHAL_OBSTACLE;
+        const bool in_obstacle = costmap.getCost(map_x, map_y) >= costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
         if (reached_point_away_from_start && in_obstacle && !local_goal_in_obstacle) {
           break;
         }

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -259,6 +259,7 @@ namespace base_local_planner{
         local_goal_in_obstacle = in_obstacle;
       } else {
         if (started_path) {
+          ROS_WARN_COND(local_goal_in_obstacle, "local goal in obstacle");
           break;
         }// else we might have a non pruned path, so we just continue
       }


### PR DESCRIPTION
Currently, if the goal is in obstacle / surrounded by obstacles, the local planner rejects all trajectories. This is because all the cells have goal cost = `obstacle cost`.

So if painting obstacles in the local costmap only, this is the behavior we get:

https://user-images.githubusercontent.com/4960007/199883519-cebe04f4-63c6-41f0-b2aa-e52ba2673cb3.mp4

The way the local goal is decided is by following the path points until `NO_INFORMATION` cost is encountered or we reach the map limits.

What I changed in this PR is to add a check whether the path point is in an obstacle, and once we've searched the path for some distance, the search is stopped if once we encounter an obstacle and we found an path point without obstacle before (for more details, check the comment in the code)

So the behavior now is (simplified): "If the (path to) the goal is blocked, just keep moving until within 1m of the obstruction".
The result looks like this:

https://user-images.githubusercontent.com/4960007/199885068-5a20802c-b68f-49fa-9453-0d3dbd792537.mp4

Let me know if you have any other ideas.

