### PR TITLE
Fix random zero vel cmds

### DIFF
--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -136,7 +136,8 @@ double ObstacleCostFunction::getScalingFactor(const Trajectory &traj, double sca
   //if we're over a certain speed threshold, we'll scale the robot's
   //footprint to make it either slow down or stay further from walls
   //scale up to 1 linearly... this could be changed later
-  return vmag <= scaling_speed ? 0.0 : (vmag - scaling_speed) / (max_trans_vel - scaling_speed);
+  const double scale = vmag <= scaling_speed ? 0.0 : (vmag - scaling_speed) / (max_trans_vel - scaling_speed);
+  return std::max(0.0, std::min(1.0, scale));
 }
 
 double ObstacleCostFunction::footprintCost (

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -170,7 +170,6 @@ namespace dwa_local_planner {
 
       std::vector<geometry_msgs::PoseStamped> global_plan_;
 
-      boost::mutex configuration_mutex_;
       std::string frame_id_;
       ros::Publisher traj_cloud_pub_;
       bool publish_cost_grid_pc_; ///< @brief Whether or not to build and publish a PointCloud

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -198,6 +198,9 @@ namespace dwa_local_planner {
       bool latched_inner_goal_;
       std::vector<geometry_msgs::PoseStamped> transformed_plan_;
       boost::optional<geometry_msgs::PoseStamped> outer_goal_entry_;
+
+      // mutex to avoid reconfigure while we're scoring trajectories
+      std::mutex config_mtx_;
   };
 };
 #endif

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -51,9 +51,6 @@
 namespace dwa_local_planner {
   void DWAPlanner::reconfigure(DWAPlannerConfig &config)
   {
-
-    boost::mutex::scoped_lock l(configuration_mutex_);
-
     generator_.setParameters(
         config.sim_time,
         config.sim_granularity,
@@ -374,9 +371,6 @@ namespace dwa_local_planner {
       const geometry_msgs::PoseStamped& global_pose,
       const geometry_msgs::PoseStamped& global_vel,
       geometry_msgs::PoseStamped& drive_velocities) {
-
-    //make sure that our configuration doesn't change mid-run
-    boost::mutex::scoped_lock l(configuration_mutex_);
 
     Eigen::Vector3f pos(global_pose.pose.position.x, global_pose.pose.position.y, tf2::getYaw(global_pose.pose.orientation));
     Eigen::Vector3f vel(global_vel.pose.position.x, global_vel.pose.position.y, tf2::getYaw(global_vel.pose.orientation));

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -59,6 +59,8 @@ PLUGINLIB_EXPORT_CLASS(dwa_local_planner::DWAPlannerROS, mbf_costmap_core::Costm
 namespace dwa_local_planner {
 
   void DWAPlannerROS::reconfigureCB(DWAPlannerConfig &config, uint32_t level) {
+      const std::lock_guard<std::mutex> lock(config_mtx_);
+      
       if (setup_ && config.restore_defaults) {
         config = default_config_;
         config.restore_defaults = false;
@@ -271,6 +273,7 @@ namespace dwa_local_planner {
     drive_cmds.header.frame_id = costmap_ros_->getBaseFrameID();
 
     // call with updated footprint
+    std::lock_guard<std::mutex> lock(config_mtx_);
     base_local_planner::Trajectory path = dp_->findBestPath(global_pose, robot_vel, drive_cmds);
     //ROS_ERROR("Best: %.2f, %.2f, %.2f, %.2f", path.xv_, path.yv_, path.thetav_, path.cost_);
 


### PR DESCRIPTION
## Description

The configuration object containing `max_vel_trans` is a member of `base_local_planner::LocalPlannerUtil`, not `DWAPlanner`.
Which means it is not protected by `DWAPlanner::configuration_mutex_`.

So it is possible that `max_vel_trans` would be reconfigured while in the middle of scoring trajectories.
This could lead to the equation for computing the footprint scale factor becoming invalid (`vmag` > `max_vel_trans`), causing the footprint to scale to infinity.
This resulted in every trajectory being in collision and thus sending zero vel cmd.

This PR fixes it by moving the `DWAPlanner::configuration_mutex_` one level up (`DWAPlanner` -> `DWAPlannerROS`), protecting both `planner_util_` and `dp_` at the same time.

However there is still a small issue that sometimes the trajectory velocity will be higher than `max_vel_trans` due to this epsilon check:

https://github.com/rapyuta-robotics/ros-navigation/blob/28e8fcec130040a175411b2736b4de0abd0caa26/base_local_planner/src/simple_trajectory_generator.cpp#L215-L218

So I also added clamping of the footprint scale factor to make sure it stays within [0.0, 1.0].

**Bonus:** use `std` mutex instead of `boost`