### PR TITLE
On NO_VALID_CMD, return the current twist but decelerating as much as allowed

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -189,6 +189,7 @@ namespace dwa_local_planner {
 
       bool initialized_;
 
+      double controller_frequency_; ///< Calling frequency to this plugin
 
       base_local_planner::OdometryHelperRos odom_helper_;
       std::string odom_topic_;


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1016710285

Requires:
- https://github.com/magazino/move_base_flex/pull/306
- setting `/move_base_flex/force_stop_on_retry` to fase (defaults to true)

Here I run the robot on a straight route and kick fast in front.

before speed drops to 0 on every kick
![image](https://user-images.githubusercontent.com/322610/205846993-d76a304f-d1bb-41b6-8d26-0584657984ff.png)

after it doesn't. it slows down at 2 m/s^2
:warning:   this test is a bit forced test, because this feature works as long as we keep retrying and have not reached patience time. So I have set both to infinity. In real operation, we will have 2 or 3 retries, what in most cases will avoid the sharp brakings
(more details on MBF PR)
![image](https://user-images.githubusercontent.com/322610/205846581-99f19b4b-f34c-4bf3-acd1-e7eee1d06d3a.png)

