### PR TITLE
return ExePathResult outcome in MapGridCostFunction::prepare()

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -mbf_abstract_core -mbf_abstract_nav -mbf_costmap_core -mbf_costmap_nav -mbf_simple_nav'}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, DOWNSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -mbf_abstract_core -mbf_abstract_nav -mbf_costmap_core -mbf_costmap_nav -mbf_simple_nav'}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -17,11 +17,7 @@ jobs:
   industrial_ci:
     name: ros-navigation-industrial-ci
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        env:
-          - {ROS_DISTRO: noetic, ROS_REPO: main}
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: ${{matrix.env}}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, ROSINSTALL_FILENAME: ros_navigation.rosinstall}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: {ROS_DISTRO: noetic, ROS_REPO: main, ROSINSTALL_FILENAME: ros_navigation.rosinstall}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: ros_navigation.rosinstall}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: {ROS_DISTRO: noetic, ROS_REPO: main, DOWNSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -mbf_abstract_core -mbf_abstract_nav -mbf_costmap_core -mbf_costmap_nav -mbf_simple_nav'}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -move_base_flex/mbf_abstract_core -move_base_flex/mbf_abstract_nav -move_base_flex/mbf_costmap_core -move_base_flex/mbf_costmap_nav -move_base_flex/mbf_simple_nav'}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: ros_navigation.rosinstall}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -mbf_abstract_core -mbf_abstract_nav -mbf_costmap_core -mbf_costmap_nav -mbf_simple_nav'}

--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED
             geometry_msgs
             message_generation
             mbf_msgs
+            mbf_utility
             nav_core
             nav_msgs
             pluginlib

--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
             dynamic_reconfigure
             geometry_msgs
             message_generation
+            mbf_msgs
             nav_core
             nav_msgs
             pluginlib

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <geometry_msgs/PoseStamped.h>
-#include <mbf_msgs/ExePathResult.h>
 #include <base_local_planner/trajectory_cost_function.h>
+
 namespace base_local_planner {
 
 constexpr double MAX_ANGLE_ERROR = 0.8;
@@ -14,7 +14,7 @@ public:
 
   void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose);
 
-  mbf_msgs::ExePathResult::_outcome_type prepare();
+  ExePathOutcome prepare();
 
   double scoreTrajectory(Trajectory &traj);
 

--- a/base_local_planner/include/base_local_planner/align_with_path_function.h
+++ b/base_local_planner/include/base_local_planner/align_with_path_function.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <geometry_msgs/PoseStamped.h>
+#include <mbf_msgs/ExePathResult.h>
 #include <base_local_planner/trajectory_cost_function.h>
-
 namespace base_local_planner {
 
 constexpr double MAX_ANGLE_ERROR = 0.8;
@@ -14,7 +14,7 @@ public:
 
   void setTargetPoses(std::vector<geometry_msgs::PoseStamped>& target_poses, const geometry_msgs::PoseStamped& global_pose);
 
-  bool prepare();
+  mbf_msgs::ExePathResult::_outcome_type prepare();
 
   double scoreTrajectory(Trajectory &traj);
 

--- a/base_local_planner/include/base_local_planner/map_grid.h
+++ b/base_local_planner/include/base_local_planner/map_grid.h
@@ -43,6 +43,7 @@
 #include <base_local_planner/map_cell.h>
 #include <costmap_2d/costmap_2d.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner{
   /**
@@ -178,12 +179,12 @@ namespace base_local_planner{
       /**
        * @brief Update what cells are considered path based on the global plan 
        */
-      void setTargetCells(const costmap_2d::Costmap2D& costmap, const std::vector<geometry_msgs::PoseStamped>& global_plan);
+      mbf_msgs::ExePathResult::_outcome_type setTargetCells(const costmap_2d::Costmap2D& costmap, const std::vector<geometry_msgs::PoseStamped>& global_plan);
 
       /**
        * @brief Update what cell is considered the next local goal
        */
-      void setLocalGoal(const costmap_2d::Costmap2D& costmap,
+      mbf_msgs::ExePathResult::_outcome_type setLocalGoal(const costmap_2d::Costmap2D& costmap,
             const std::vector<geometry_msgs::PoseStamped>& global_plan);
 
       double goal_x_, goal_y_; /**< @brief The goal distance was last computed from */

--- a/base_local_planner/include/base_local_planner/map_grid.h
+++ b/base_local_planner/include/base_local_planner/map_grid.h
@@ -41,9 +41,9 @@
 #include <ros/ros.h>
 
 #include <base_local_planner/map_cell.h>
+#include <base_local_planner/types.h>
 #include <costmap_2d/costmap_2d.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner{
   /**
@@ -179,12 +179,12 @@ namespace base_local_planner{
       /**
        * @brief Update what cells are considered path based on the global plan 
        */
-      mbf_msgs::ExePathResult::_outcome_type setTargetCells(const costmap_2d::Costmap2D& costmap, const std::vector<geometry_msgs::PoseStamped>& global_plan);
+      ExePathOutcome setTargetCells(const costmap_2d::Costmap2D& costmap, const std::vector<geometry_msgs::PoseStamped>& global_plan);
 
       /**
        * @brief Update what cell is considered the next local goal
        */
-      mbf_msgs::ExePathResult::_outcome_type setLocalGoal(const costmap_2d::Costmap2D& costmap,
+      ExePathOutcome setLocalGoal(const costmap_2d::Costmap2D& costmap,
             const std::vector<geometry_msgs::PoseStamped>& global_plan);
 
       double goal_x_, goal_y_; /**< @brief The goal distance was last computed from */

--- a/base_local_planner/include/base_local_planner/map_grid_cost_function.h
+++ b/base_local_planner/include/base_local_planner/map_grid_cost_function.h
@@ -40,9 +40,9 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 
+#include <mbf_msgs/ExePathResult.h>
 #include <costmap_2d/costmap_2d.h>
 #include <base_local_planner/map_grid.h>
-
 namespace base_local_planner {
 
 /**
@@ -96,7 +96,7 @@ public:
   /**
    * propagate distances
    */
-  bool prepare();
+  mbf_msgs::ExePathResult::_outcome_type prepare();
 
   double scoreTrajectory(Trajectory &traj);
 

--- a/base_local_planner/include/base_local_planner/map_grid_cost_function.h
+++ b/base_local_planner/include/base_local_planner/map_grid_cost_function.h
@@ -40,7 +40,6 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 
-#include <mbf_msgs/ExePathResult.h>
 #include <costmap_2d/costmap_2d.h>
 #include <base_local_planner/map_grid.h>
 namespace base_local_planner {
@@ -96,7 +95,7 @@ public:
   /**
    * propagate distances
    */
-  mbf_msgs::ExePathResult::_outcome_type prepare();
+  ExePathOutcome prepare();
 
   double scoreTrajectory(Trajectory &traj);
 

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -40,6 +40,8 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 
+#include <mbf_msgs/ExePathResult.h>
+
 #include <base_local_planner/costmap_model.h>
 #include <costmap_2d/costmap_2d.h>
 
@@ -56,7 +58,7 @@ public:
   ObstacleCostFunction(costmap_2d::Costmap2D* costmap);
   ~ObstacleCostFunction();
 
-  bool prepare();
+  mbf_msgs::ExePathResult::_outcome_type prepare();
   double scoreTrajectory(Trajectory &traj);
 
   void setSumScores(bool score_sums){ sum_scores_=score_sums; }

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -40,8 +40,6 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 
-#include <mbf_msgs/ExePathResult.h>
-
 #include <base_local_planner/costmap_model.h>
 #include <costmap_2d/costmap_2d.h>
 
@@ -58,7 +56,7 @@ public:
   ObstacleCostFunction(costmap_2d::Costmap2D* costmap);
   ~ObstacleCostFunction();
 
-  mbf_msgs::ExePathResult::_outcome_type prepare();
+  ExePathOutcome prepare();
   double scoreTrajectory(Trajectory &traj);
 
   void setSumScores(bool score_sums){ sum_scores_=score_sums; }

--- a/base_local_planner/include/base_local_planner/oscillation_cost_function.h
+++ b/base_local_planner/include/base_local_planner/oscillation_cost_function.h
@@ -40,7 +40,6 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 #include <Eigen/Core>
-#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -51,7 +50,7 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
-  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
+  ExePathOutcome prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 
   /**
    * @brief  Reset the oscillation flags for the local planner

--- a/base_local_planner/include/base_local_planner/oscillation_cost_function.h
+++ b/base_local_planner/include/base_local_planner/oscillation_cost_function.h
@@ -40,6 +40,7 @@
 
 #include <base_local_planner/trajectory_cost_function.h>
 #include <Eigen/Core>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -50,7 +51,7 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
-  bool prepare() {return true;};
+  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 
   /**
    * @brief  Reset the oscillation flags for the local planner

--- a/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
+++ b/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
@@ -39,14 +39,14 @@
 #define PREFER_FORWARD_COST_FUNCTION_H_
 
 #include <base_local_planner/trajectory_cost_function.h>
-
+#include <mbf_msgs/ExePathResult.h>
 namespace base_local_planner {
 
 class PreferForwardCostFunction: public base_local_planner::TrajectoryCostFunction {
 public:
   double scoreTrajectory(Trajectory &traj);
 
-  bool prepare() {return true;};
+  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
+++ b/base_local_planner/include/base_local_planner/prefer_forward_cost_function.h
@@ -39,14 +39,14 @@
 #define PREFER_FORWARD_COST_FUNCTION_H_
 
 #include <base_local_planner/trajectory_cost_function.h>
-#include <mbf_msgs/ExePathResult.h>
+
 namespace base_local_planner {
 
 class PreferForwardCostFunction: public base_local_planner::TrajectoryCostFunction {
 public:
   double scoreTrajectory(Trajectory &traj);
 
-  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
+  ExePathOutcome prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/simple_scored_sampling_planner.h
+++ b/base_local_planner/include/base_local_planner/simple_scored_sampling_planner.h
@@ -92,7 +92,7 @@ public:
    * @param traj The container to write the result to
    * @param all_explored pass NULL or a container to collect all trajectories for debugging (has a penalty)
    */
-   mbf_msgs::ExePathResult::_outcome_type findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored = 0);
+   ExePathOutcome findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored = 0);
 
 
 private:

--- a/base_local_planner/include/base_local_planner/simple_scored_sampling_planner.h
+++ b/base_local_planner/include/base_local_planner/simple_scored_sampling_planner.h
@@ -39,6 +39,7 @@
 #define SIMPLE_SCORED_SAMPLING_PLANNER_H_
 
 #include <vector>
+#include <mbf_msgs/ExePathResult.h>
 #include <base_local_planner/trajectory.h>
 #include <base_local_planner/trajectory_cost_function.h>
 #include <base_local_planner/trajectory_sample_generator.h>
@@ -91,7 +92,7 @@ public:
    * @param traj The container to write the result to
    * @param all_explored pass NULL or a container to collect all trajectories for debugging (has a penalty)
    */
-  bool findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored = 0);
+   mbf_msgs::ExePathResult::_outcome_type findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored = 0);
 
 
 private:

--- a/base_local_planner/include/base_local_planner/trajectory_cost_function.h
+++ b/base_local_planner/include/base_local_planner/trajectory_cost_function.h
@@ -39,7 +39,7 @@
 #define TRAJECTORYCOSTFUNCTION_H_
 
 #include <base_local_planner/trajectory.h>
-#include <mbf_msgs/ExePathResult.h>
+#include <base_local_planner/types.h>
 
 namespace base_local_planner {
 
@@ -58,7 +58,7 @@ public:
    * General updating of context values if required.
    * Subclasses may overwrite. Return a non-zero error code in case there is any error.
    */
-  virtual mbf_msgs::ExePathResult::_outcome_type prepare() = 0;
+  virtual ExePathOutcome prepare() = 0;
 
   /**
    * return a score for trajectory traj

--- a/base_local_planner/include/base_local_planner/trajectory_cost_function.h
+++ b/base_local_planner/include/base_local_planner/trajectory_cost_function.h
@@ -39,6 +39,7 @@
 #define TRAJECTORYCOSTFUNCTION_H_
 
 #include <base_local_planner/trajectory.h>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -55,9 +56,9 @@ public:
   /**
    *
    * General updating of context values if required.
-   * Subclasses may overwrite. Return false in case there is any error.
+   * Subclasses may overwrite. Return a non-zero error code in case there is any error.
    */
-  virtual bool prepare() = 0;
+  virtual mbf_msgs::ExePathResult::_outcome_type prepare() = 0;
 
   /**
    * return a score for trajectory traj

--- a/base_local_planner/include/base_local_planner/trajectory_search.h
+++ b/base_local_planner/include/base_local_planner/trajectory_search.h
@@ -39,6 +39,7 @@
 #define TRAJECTORY_SEARCH_H_
 
 #include <base_local_planner/trajectory.h>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -56,7 +57,7 @@ public:
    * @param traj The container to write the result to
    * @param all_explored pass NULL or a container to collect all trajectories for debugging (has a penalty)
    */
-  virtual bool findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) = 0;
+  virtual mbf_msgs::ExePathResult::_outcome_type findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) = 0;
 
   virtual ~TrajectorySearch() {}
 

--- a/base_local_planner/include/base_local_planner/trajectory_search.h
+++ b/base_local_planner/include/base_local_planner/trajectory_search.h
@@ -39,7 +39,7 @@
 #define TRAJECTORY_SEARCH_H_
 
 #include <base_local_planner/trajectory.h>
-#include <mbf_msgs/ExePathResult.h>
+#include <base_local_planner/types.h>
 
 namespace base_local_planner {
 
@@ -57,7 +57,7 @@ public:
    * @param traj The container to write the result to
    * @param all_explored pass NULL or a container to collect all trajectories for debugging (has a penalty)
    */
-  virtual mbf_msgs::ExePathResult::_outcome_type findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) = 0;
+  virtual ExePathOutcome findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) = 0;
 
   virtual ~TrajectorySearch() {}
 

--- a/base_local_planner/include/base_local_planner/twirling_cost_function.h
+++ b/base_local_planner/include/base_local_planner/twirling_cost_function.h
@@ -39,7 +39,6 @@
 #define TWIRLING_COST_FUNCTION_H
 
 #include <base_local_planner/trajectory_cost_function.h>
-#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -58,7 +57,7 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
-  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
+  ExePathOutcome prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/twirling_cost_function.h
+++ b/base_local_planner/include/base_local_planner/twirling_cost_function.h
@@ -39,6 +39,7 @@
 #define TWIRLING_COST_FUNCTION_H
 
 #include <base_local_planner/trajectory_cost_function.h>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace base_local_planner {
 
@@ -57,7 +58,7 @@ public:
 
   double scoreTrajectory(Trajectory &traj);
 
-  bool prepare() {return true;};
+  mbf_msgs::ExePathResult::_outcome_type prepare() {return mbf_msgs::ExePathResult::SUCCESS;};
 };
 
 } /* namespace base_local_planner */

--- a/base_local_planner/include/base_local_planner/types.h
+++ b/base_local_planner/include/base_local_planner/types.h
@@ -1,0 +1,12 @@
+#ifndef BASE_LOCAL_PLANNER_TYPES_H_
+#define BASE_LOCAL_PLANNER_TYPES_H_
+
+#include <mbf_msgs/ExePathResult.h>
+
+namespace base_local_planner {
+
+using ExePathOutcome = mbf_msgs::ExePathResult::_outcome_type;
+
+}
+
+#endif /* BASE_LOCAL_PLANNER_TYPES_H_ */

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -29,6 +29,7 @@
     <depend>eigen</depend>
     <depend>geometry_msgs</depend>
     <depend>mbf_msgs</depend>
+    <depend>mbf_utility</depend>
     <depend>nav_core</depend>
     <depend>nav_msgs</depend>
     <depend>pluginlib</depend>

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -28,6 +28,7 @@
     <depend>dynamic_reconfigure</depend>
     <depend>eigen</depend>
     <depend>geometry_msgs</depend>
+    <depend>mbf_msgs</depend>
     <depend>nav_core</depend>
     <depend>nav_msgs</depend>
     <depend>pluginlib</depend>

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -23,7 +23,7 @@ void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStampe
   current_yaw_diff_ = angles::normalize_angle(path_yaw - current_yaw);
 }
 
-mbf_msgs::ExePathResult::_outcome_type AlignWithPathFunction::prepare() {
+ExePathOutcome AlignWithPathFunction::prepare() {
   return mbf_msgs::ExePathResult::SUCCESS;;
 }
 

--- a/base_local_planner/src/align_with_path_function.cpp
+++ b/base_local_planner/src/align_with_path_function.cpp
@@ -23,8 +23,8 @@ void AlignWithPathFunction::setTargetPoses(std::vector<geometry_msgs::PoseStampe
   current_yaw_diff_ = angles::normalize_angle(path_yaw - current_yaw);
 }
 
-bool AlignWithPathFunction::prepare() {
-  return true;
+mbf_msgs::ExePathResult::_outcome_type AlignWithPathFunction::prepare() {
+  return mbf_msgs::ExePathResult::SUCCESS;;
 }
 
 double AlignWithPathFunction::scoreTrajectory(Trajectory &traj) {

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -33,6 +33,8 @@
  *********************************************************************/
 #include <base_local_planner/map_grid.h>
 #include <costmap_2d/cost_values.h>
+#include <mbf_msgs/ExePathAction.h>
+
 using namespace std;
 
 namespace base_local_planner{
@@ -168,7 +170,7 @@ namespace base_local_planner{
   }
 
   //update what map cells are considered path based on the global_plan
-  void MapGrid::setTargetCells(const costmap_2d::Costmap2D& costmap,
+  mbf_msgs::ExePathResult::_outcome_type MapGrid::setTargetCells(const costmap_2d::Costmap2D& costmap,
       const std::vector<geometry_msgs::PoseStamped>& global_plan) {
     sizeCheck(costmap.getSizeInCellsX(), costmap.getSizeInCellsY());
 
@@ -200,14 +202,15 @@ namespace base_local_planner{
     if (!started_path) {
       ROS_ERROR("None of the %d first of %zu (%zu) points of the global plan were in the local costmap and free",
           i, adjusted_global_plan.size(), global_plan.size());
-      return;
+      return mbf_msgs::ExePathResult::OUT_OF_MAP;
     }
 
     computeTargetDistance(path_dist_queue, costmap);
+    return mbf_msgs::ExePathResult::SUCCESS;
   }
 
   //mark the point of the costmap as local goal where global_plan first leaves the area (or its last point)
-  void MapGrid::setLocalGoal(const costmap_2d::Costmap2D& costmap,
+  mbf_msgs::ExePathResult::_outcome_type MapGrid::setLocalGoal(const costmap_2d::Costmap2D& costmap,
       const std::vector<geometry_msgs::PoseStamped>& global_plan) {
     sizeCheck(costmap.getSizeInCellsX(), costmap.getSizeInCellsY());
 
@@ -265,7 +268,12 @@ namespace base_local_planner{
     }
     if (!started_path) {
       ROS_ERROR("None of the points of the global plan were in the local costmap, global plan points too far from robot");
-      return;
+      return mbf_msgs::ExePathResult::OUT_OF_MAP;
+    }
+
+    if (local_goal_in_obstacle) {
+      ROS_WARN("None of the points of the global plan sufficiently far away from the start were in free space");
+      return mbf_msgs::ExePathResult::BLOCKED_PATH;
     }
 
     queue<MapCell*> path_dist_queue;
@@ -278,6 +286,7 @@ namespace base_local_planner{
     }
 
     computeTargetDistance(path_dist_queue, costmap);
+    return mbf_msgs::ExePathResult::SUCCESS;
   }
 
 

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -33,7 +33,6 @@
  *********************************************************************/
 #include <base_local_planner/map_grid.h>
 #include <costmap_2d/cost_values.h>
-#include <mbf_msgs/ExePathAction.h>
 
 using namespace std;
 
@@ -170,7 +169,7 @@ namespace base_local_planner{
   }
 
   //update what map cells are considered path based on the global_plan
-  mbf_msgs::ExePathResult::_outcome_type MapGrid::setTargetCells(const costmap_2d::Costmap2D& costmap,
+  ExePathOutcome MapGrid::setTargetCells(const costmap_2d::Costmap2D& costmap,
       const std::vector<geometry_msgs::PoseStamped>& global_plan) {
     sizeCheck(costmap.getSizeInCellsX(), costmap.getSizeInCellsY());
 
@@ -210,7 +209,7 @@ namespace base_local_planner{
   }
 
   //mark the point of the costmap as local goal where global_plan first leaves the area (or its last point)
-  mbf_msgs::ExePathResult::_outcome_type MapGrid::setLocalGoal(const costmap_2d::Costmap2D& costmap,
+  ExePathOutcome MapGrid::setLocalGoal(const costmap_2d::Costmap2D& costmap,
       const std::vector<geometry_msgs::PoseStamped>& global_plan) {
     sizeCheck(costmap.getSizeInCellsX(), costmap.getSizeInCellsY());
 

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -273,7 +273,7 @@ namespace base_local_planner{
 
     if (local_goal_in_obstacle) {
       ROS_WARN("None of the points of the global plan sufficiently far away from the start were in free space");
-      return mbf_msgs::ExePathResult::BLOCKED_PATH;
+      return mbf_msgs::ExePathResult::BLOCKED_GOAL;
     }
 
     queue<MapCell*> path_dist_queue;

--- a/base_local_planner/src/map_grid_cost_function.cpp
+++ b/base_local_planner/src/map_grid_cost_function.cpp
@@ -56,15 +56,10 @@ void MapGridCostFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>
   target_poses_ = target_poses;
 }
 
-bool MapGridCostFunction::prepare() {
+mbf_msgs::ExePathResult::_outcome_type MapGridCostFunction::prepare() {
   map_.resetPathDist();
 
-  if (is_local_goal_function_) {
-    map_.setLocalGoal(*costmap_, target_poses_);
-  } else {
-    map_.setTargetCells(*costmap_, target_poses_);
-  }
-  return true;
+  return is_local_goal_function_ ? map_.setLocalGoal(*costmap_, target_poses_): map_.setTargetCells(*costmap_, target_poses_);
 }
 
 double MapGridCostFunction::getCellCosts(unsigned int px, unsigned int py) {

--- a/base_local_planner/src/map_grid_cost_function.cpp
+++ b/base_local_planner/src/map_grid_cost_function.cpp
@@ -56,7 +56,7 @@ void MapGridCostFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>
   target_poses_ = target_poses;
 }
 
-mbf_msgs::ExePathResult::_outcome_type MapGridCostFunction::prepare() {
+ExePathOutcome MapGridCostFunction::prepare() {
   map_.resetPathDist();
 
   return is_local_goal_function_ ? map_.setLocalGoal(*costmap_, target_poses_): map_.setTargetCells(*costmap_, target_poses_);

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -94,7 +94,7 @@ std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(const
   return scaled_footprint;
 }
 
-mbf_msgs::ExePathResult::_outcome_type ObstacleCostFunction::prepare() {
+ExePathOutcome ObstacleCostFunction::prepare() {
   return mbf_msgs::ExePathResult::SUCCESS;
 }
 

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -94,8 +94,8 @@ std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(const
   return scaled_footprint;
 }
 
-bool ObstacleCostFunction::prepare() {
-  return true;
+mbf_msgs::ExePathResult::_outcome_type ObstacleCostFunction::prepare() {
+  return mbf_msgs::ExePathResult::SUCCESS;
 }
 
 double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {

--- a/base_local_planner/src/simple_scored_sampling_planner.cpp
+++ b/base_local_planner/src/simple_scored_sampling_planner.cpp
@@ -38,6 +38,7 @@
 #include <base_local_planner/simple_scored_sampling_planner.h>
 
 #include <ros/console.h>
+#include <mbf_utility/navigation_utility.h>
 
 namespace base_local_planner {
   
@@ -88,7 +89,7 @@ namespace base_local_planner {
       TrajectoryCostFunction* loop_critic_p = *loop_critic;
       const auto outcome = loop_critic_p->prepare();
       if (outcome != mbf_msgs::ExePathResult::SUCCESS) {
-        ROS_WARN_STREAM("A scoring function failed to prepare; outcome: " << outcome);
+        ROS_WARN_STREAM("A scoring function failed to prepare; outcome: " << mbf_utility::outcome2str(outcome));
         return outcome;
       }
     }

--- a/base_local_planner/src/simple_scored_sampling_planner.cpp
+++ b/base_local_planner/src/simple_scored_sampling_planner.cpp
@@ -79,7 +79,7 @@ namespace base_local_planner {
     return traj_cost;
   }
 
-  mbf_msgs::ExePathResult::_outcome_type SimpleScoredSamplingPlanner::findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) {
+  ExePathOutcome SimpleScoredSamplingPlanner::findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) {
     Trajectory loop_traj;
     Trajectory best_traj;
     double loop_traj_cost, best_traj_cost = -1;

--- a/base_local_planner/src/simple_scored_sampling_planner.cpp
+++ b/base_local_planner/src/simple_scored_sampling_planner.cpp
@@ -78,7 +78,7 @@ namespace base_local_planner {
     return traj_cost;
   }
 
-  bool SimpleScoredSamplingPlanner::findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) {
+  mbf_msgs::ExePathResult::_outcome_type SimpleScoredSamplingPlanner::findBestTrajectory(Trajectory& traj, std::vector<Trajectory>* all_explored) {
     Trajectory loop_traj;
     Trajectory best_traj;
     double loop_traj_cost, best_traj_cost = -1;
@@ -86,9 +86,10 @@ namespace base_local_planner {
     int count, count_valid;
     for (std::vector<TrajectoryCostFunction*>::iterator loop_critic = critics_.begin(); loop_critic != critics_.end(); ++loop_critic) {
       TrajectoryCostFunction* loop_critic_p = *loop_critic;
-      if (loop_critic_p->prepare() == false) {
-        ROS_WARN("A scoring function failed to prepare");
-        return false;
+      const auto outcome = loop_critic_p->prepare();
+      if (outcome != mbf_msgs::ExePathResult::SUCCESS) {
+        ROS_WARN_STREAM("A scoring function failed to prepare; outcome: " << outcome);
+        return outcome;
       }
     }
 
@@ -138,7 +139,7 @@ namespace base_local_planner {
         break;
       }
     }
-    return best_traj_cost >= 0;
+    return best_traj_cost >= 0 ? mbf_msgs::ExePathResult::SUCCESS : mbf_msgs::ExePathResult::NO_VALID_CMD;
   }
 
   

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -66,6 +66,7 @@
 #include <mbf_msgs/ExePathResult.h>
 
 namespace dwa_local_planner {
+  using ExePathOutcome = mbf_msgs::ExePathResult::_outcome_type;
   /**
    * @class DWAPlanner
    * @brief A class implementing a local planner using the Dynamic Window Approach
@@ -104,7 +105,7 @@ namespace dwa_local_planner {
        * @param drive_velocities The velocities to send to the robot base
        * @return The highest scoring trajectory. A cost >= 0 means the trajectory is legal to execute.
        */
-      std::pair<base_local_planner::Trajectory, mbf_msgs::ExePathResult::_outcome_type> findBestPath(
+      std::pair<base_local_planner::Trajectory, ExePathOutcome> findBestPath(
           const geometry_msgs::PoseStamped& global_pose,
           const geometry_msgs::PoseStamped& global_vel,
           geometry_msgs::PoseStamped& drive_velocities);

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -63,6 +63,7 @@
 #include <base_local_planner/simple_scored_sampling_planner.h>
 
 #include <nav_msgs/Path.h>
+#include <mbf_msgs/ExePathResult.h>
 
 namespace dwa_local_planner {
   /**
@@ -103,7 +104,7 @@ namespace dwa_local_planner {
        * @param drive_velocities The velocities to send to the robot base
        * @return The highest scoring trajectory. A cost >= 0 means the trajectory is legal to execute.
        */
-      base_local_planner::Trajectory findBestPath(
+      std::pair<base_local_planner::Trajectory, mbf_msgs::ExePathResult::_outcome_type> findBestPath(
           const geometry_msgs::PoseStamped& global_pose,
           const geometry_msgs::PoseStamped& global_vel,
           geometry_msgs::PoseStamped& drive_velocities);

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -112,7 +112,7 @@ namespace dwa_local_planner {
        *         INTERNAL_ERROR  = 114
        *         121..149 are reserved as plugin specific errors
        */
-      uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
+      ExePathOutcome computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                        const geometry_msgs::TwistStamped& velocity,
                                        geometry_msgs::TwistStamped& cmd_vel, std::string& message);
 
@@ -124,7 +124,7 @@ namespace dwa_local_planner {
        * @param message Optional more detailed outcome as a string.
        * @return Result code as described on ExePath action result (see computeVelocityCommands for details)
        */
-      uint32_t dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
+      ExePathOutcome dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
                                           geometry_msgs::TwistStamped& cmd_vel, std::string& message);
 
       /**

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -112,7 +112,7 @@ namespace dwa_local_planner {
        *         INTERNAL_ERROR  = 114
        *         121..149 are reserved as plugin specific errors
        */
-      ExePathOutcome computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
+      uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                        const geometry_msgs::TwistStamped& velocity,
                                        geometry_msgs::TwistStamped& cmd_vel, std::string& message);
 
@@ -124,7 +124,7 @@ namespace dwa_local_planner {
        * @param message Optional more detailed outcome as a string.
        * @return Result code as described on ExePath action result (see computeVelocityCommands for details)
        */
-      ExePathOutcome dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
+      uint32_t dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
                                           geometry_msgs::TwistStamped& cmd_vel, std::string& message);
 
       /**

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -367,7 +367,7 @@ namespace dwa_local_planner {
   /*
    * given the current state of the robot, find a good trajectory
    */
-  std::pair<base_local_planner::Trajectory, mbf_msgs::ExePathResult::_outcome_type> DWAPlanner::findBestPath(
+  std::pair<base_local_planner::Trajectory, ExePathOutcome> DWAPlanner::findBestPath(
       const geometry_msgs::PoseStamped& global_pose,
       const geometry_msgs::PoseStamped& global_vel,
       geometry_msgs::PoseStamped& drive_velocities) {

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -367,7 +367,7 @@ namespace dwa_local_planner {
   /*
    * given the current state of the robot, find a good trajectory
    */
-  base_local_planner::Trajectory DWAPlanner::findBestPath(
+  std::pair<base_local_planner::Trajectory, mbf_msgs::ExePathResult::_outcome_type> DWAPlanner::findBestPath(
       const geometry_msgs::PoseStamped& global_pose,
       const geometry_msgs::PoseStamped& global_vel,
       geometry_msgs::PoseStamped& drive_velocities) {
@@ -388,7 +388,7 @@ namespace dwa_local_planner {
     result_traj_.cost_ = -7;
     // find best trajectory by sampling and scoring the samples
     std::vector<base_local_planner::Trajectory> all_explored;
-    scored_sampling_planner_.findBestTrajectory(result_traj_, &all_explored);
+    const auto outcome = scored_sampling_planner_.findBestTrajectory(result_traj_, &all_explored);
 
     if(publish_traj_pc_)
     {
@@ -459,6 +459,6 @@ namespace dwa_local_planner {
       tf2::convert(q, drive_velocities.pose.orientation);
     }
 
-    return result_traj_;
+    return std::make_pair(result_traj_, outcome);
   }
 };

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -257,7 +257,7 @@ namespace dwa_local_planner {
     return latched_inner_goal_ ||  bypassed_goal || oscillating_;
   }
 
-  uint32_t DWAPlannerROS::dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
+  ExePathOutcome DWAPlannerROS::dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
                                                      geometry_msgs::TwistStamped& cmd_vel, std::string& message) {
     // dynamic window sampling approach to get useful velocity commands
     if(! isInitialized()){
@@ -352,7 +352,7 @@ namespace dwa_local_planner {
     return mbf_msgs::ExePathResult::SUCCESS;
   }
 
-  uint32_t DWAPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
+  ExePathOutcome DWAPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                                   const geometry_msgs::TwistStamped& velocity,
                                                   geometry_msgs::TwistStamped& cmd_vel, std::string& message) {
     // dispatches to either dwa sampling control or stop and rotate control, depending on whether we have been close enough to goal

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -257,7 +257,7 @@ namespace dwa_local_planner {
     return latched_inner_goal_ ||  bypassed_goal || oscillating_;
   }
 
-  ExePathOutcome DWAPlannerROS::dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
+  uint32_t DWAPlannerROS::dwaComputeVelocityCommands(geometry_msgs::PoseStamped& global_pose,
                                                      geometry_msgs::TwistStamped& cmd_vel, std::string& message) {
     // dynamic window sampling approach to get useful velocity commands
     if(! isInitialized()){
@@ -352,7 +352,7 @@ namespace dwa_local_planner {
     return mbf_msgs::ExePathResult::SUCCESS;
   }
 
-  ExePathOutcome DWAPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
+  uint32_t DWAPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                                   const geometry_msgs::TwistStamped& velocity,
                                                   geometry_msgs::TwistStamped& cmd_vel, std::string& message) {
     // dispatches to either dwa sampling control or stop and rotate control, depending on whether we have been close enough to goal

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -52,6 +52,7 @@
 #include <nav_core/parameter_magic.h>
 
 #include <mbf_msgs/ExePathResult.h>
+#include <mbf_utility/navigation_utility.h>
 
 // register this planner as a MBF's CostmapController plugin
 PLUGINLIB_EXPORT_CLASS(dwa_local_planner::DWAPlannerROS, mbf_costmap_core::CostmapController)
@@ -315,7 +316,7 @@ namespace dwa_local_planner {
       ROS_DEBUG_NAMED("dwa_local_planner", "Slowing down from (%.2f, %.2f, %.2f) to (%.2f, %.2f, %.2f)",
                       vx, vy, vt, cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z);
 
-      message = "The dwa local planner failed with an error: " + std::to_string(outcome);
+      message = "The dwa local planner failed with an error: " + mbf_utility::outcome2str(outcome);
       ROS_DEBUG_STREAM_NAMED("dwa_local_planner", message);  //// TODO why is this DEBUG?
       local_plan.clear();
       publishLocalPlan(local_plan);

--- a/ros_navigation.rosinstall
+++ b/ros_navigation.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: move_base_flex
-    uri: git@github.com:magazino/move_base_flex.git
-    version: master

--- a/ros_navigation.rosinstall
+++ b/ros_navigation.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: move_base_flex
+    uri: git@github.com:magazino/move_base_flex.git
+    version: master


### PR DESCRIPTION
## Description

wrike task: https://www.wrike.com/open.htm?id=1020463006

dependent, already merged [PR](https://github.com/magazino/move_base_flex/pull/309)

- change return type of `prepare()` and a few other methods to `mbf_msgs::ExePathResult::_outcome_type`
- change DWA planner to return:
    - `OUT_OF_MAP` if the path is out of map
    - `BLOCKED_GOAL` if the goal is blocked
    - `NO_VALID_CMD` if all trajectories are rejected for other reasons than the two above
    - `SUCCESS` if successful

## Testing

Before:

https://user-images.githubusercontent.com/4960007/207002897-2259bc4a-5878-44cf-8af4-8f79bbff09ec.mp4

After:

https://user-images.githubusercontent.com/4960007/207002831-06926565-9444-4eff-b6e4-5c65441347a1.mp4

