### PR TITLE
ObstacleCostFunction: check whether current pose is in collision

### DIFF
--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -40,6 +40,7 @@
 #include <Eigen/Core>
 #include <ros/console.h>
 #include <std_msgs/Float32.h>
+#include <tf2/utils.h>
 
 namespace base_local_planner {
 
@@ -95,7 +96,9 @@ std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(const
 }
 
 ExePathOutcome ObstacleCostFunction::prepare(const geometry_msgs::PoseStamped& current_pose) {
-  return mbf_msgs::ExePathResult::SUCCESS;
+  Trajectory traj;
+  traj.addPoint(current_pose.pose.position.x, current_pose.pose.position.y, tf2::getYaw(current_pose.pose.orientation));
+  return scoreTrajectory(traj) < 0 ? mbf_msgs::ExePathResult::COLLISION : mbf_msgs::ExePathResult::SUCCESS;
 }
 
 double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {


### PR DESCRIPTION
## Description

https://www.wrike.com/open.htm?id=1020463025

Report that the start is blocked in the ObstacleCost critic used by the DWA planner.

One small thing to note is that I added a small change a while back to just ignore the first point of the trajectory, such that the robot has a higher chance to move away from an obstacle slightly touching the footprint:

https://github.com/rapyuta-robotics/ros-navigation/blob/f2df1e5cd8e9fec0e85e8ed31a136ba3e9ae9fdf/base_local_planner/src/obstacle_cost_function.cpp#L116-L122

What do you think? Options I see:
- we don't care (and let the slow_escape recovery deal with it); not so nice because the ObstacleCost critic in internally inconsistent
- pass a reference to the generator to the ObstacleCost critic, and generate a bunch of trajectories (e.g. all combinations of `vx in [-min_vel_trans, 0, min_vel_trans]` and `v_theta in [-min_vel_theta, 0, min_vel_theta]`) with 2 points, and return SUCCESS if we found one that has cost >=0

## Testing

https://user-images.githubusercontent.com/4960007/208072042-5fd9cafe-0819-4fc2-921a-e1b8325d3f28.mp4



