### PR TITLE
MapGrid::setLocalGoal: check whether goal is reachable from start

### DIFF
--- a/base_local_planner/include/base_local_planner/map_grid.h
+++ b/base_local_planner/include/base_local_planner/map_grid.h
@@ -185,7 +185,8 @@ namespace base_local_planner{
        * @brief Update what cell is considered the next local goal
        */
       ExePathOutcome setLocalGoal(const costmap_2d::Costmap2D& costmap,
-            const std::vector<geometry_msgs::PoseStamped>& global_plan);
+            const std::vector<geometry_msgs::PoseStamped>& global_plan,
+            const geometry_msgs::PoseStamped* const current_pose = nullptr);
 
       double goal_x_, goal_y_; /**< @brief The goal distance was last computed from */
 

--- a/base_local_planner/src/map_grid_cost_function.cpp
+++ b/base_local_planner/src/map_grid_cost_function.cpp
@@ -59,7 +59,7 @@ void MapGridCostFunction::setTargetPoses(std::vector<geometry_msgs::PoseStamped>
 ExePathOutcome MapGridCostFunction::prepare(const geometry_msgs::PoseStamped& current_pose) {
   map_.resetPathDist();
 
-  return is_local_goal_function_ ? map_.setLocalGoal(*costmap_, target_poses_): map_.setTargetCells(*costmap_, target_poses_);
+  return is_local_goal_function_ ? map_.setLocalGoal(*costmap_, target_poses_, &current_pose) : map_.setTargetCells(*costmap_, target_poses_);
 }
 
 double MapGridCostFunction::getCellCosts(unsigned int px, unsigned int py) {


### PR DESCRIPTION
## Description

https://www.wrike.com/open.htm?id=1020463048

After expanding the cells from the goal, check whether the start is reachable. I made the `current_pose` argument of ` `setLocalGoal` a pointer argument because the `TrajectoryPlanner` class also uses the `setLocalGoal` method.

## Testing

Like before, the robot continues until 1m in front of the obstacle. But now, it reports "blocked path" when the path is blocked, and "blocked goal" when the goal is blocked:

https://user-images.githubusercontent.com/4960007/208082485-de0f442a-c181-4219-a286-25533da5b8fe.mp4






