### PR TITLE
Restore the option of using a costmap_2d without ROS wrapper

### DIFF
--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -71,11 +71,13 @@ class GlobalPlanner : public mbf_costmap_core::CostmapPlanner {
         GlobalPlanner();
 
         /**
-         * @brief  Constructor for the PlannerCore object
+         * @brief  Alternative constructor to use the planner outside MBF
+         * @warning Show footprint radii will not work
          * @param  name The name of this planner
-         * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning
+         * @param  costmap A pointer to the costmap to use
+         * @param  frame_id Frame of the costmap
          */
-        GlobalPlanner(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
+        GlobalPlanner(std::string name, costmap_2d::Costmap2D* costmap, std::string frame_id);
 
         /**
          * @brief  Default deconstructor for the PlannerCore object
@@ -88,6 +90,8 @@ class GlobalPlanner : public mbf_costmap_core::CostmapPlanner {
          * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning
          */
         void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
+
+        void initialize(std::string name, costmap_2d::Costmap2D* costmap, std::string frame_id);
 
         /**
          * @brief Given a goal pose in the world, compute a plan
@@ -178,8 +182,8 @@ class GlobalPlanner : public mbf_costmap_core::CostmapPlanner {
         /**
          * @brief Store a copy of the current costmap in \a costmap.  Called by makePlan.
          */
-        costmap_2d::Costmap2DROS* costmap_ros_;
-        costmap_2d::Costmap2D* costmap_;
+        costmap_2d::Costmap2DROS* costmap_ros_ = nullptr;
+        costmap_2d::Costmap2D* costmap_ = nullptr;
         std::string frame_id_;
         ros::Publisher plan_pub_;
         bool initialized_, allow_unknown_;

--- a/global_planner/src/plan_node.cpp
+++ b/global_planner/src/plan_node.cpp
@@ -92,7 +92,7 @@ void PlannerWithCostmap::poseCallback(const rm::PoseStamped::ConstPtr& goal) {
 }
 
 PlannerWithCostmap::PlannerWithCostmap(string name, Costmap2DROS* cmap) :
-        GlobalPlanner(name, cmap) {
+        GlobalPlanner(name, cmap->getCostmap(), cmap->getGlobalFrameID()) {
     ros::NodeHandle private_nh("~");
     cmap_ = cmap;
     make_plan_service_ = private_nh.advertiseService("make_plan", &PlannerWithCostmap::makePlanService, this);

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -75,10 +75,10 @@ GlobalPlanner::GlobalPlanner() :
         potential_array_(NULL) {
 }
 
-GlobalPlanner::GlobalPlanner(std::string name, costmap_2d::Costmap2DROS* costmap_ros) :
+GlobalPlanner::GlobalPlanner(std::string name, costmap_2d::Costmap2D* costmap, std::string frame_id) :
         GlobalPlanner() {
     //initialize the planner
-    initialize(name, costmap_ros);
+    initialize(name, costmap, frame_id);
 }
 
 GlobalPlanner::~GlobalPlanner() {
@@ -93,13 +93,17 @@ GlobalPlanner::~GlobalPlanner() {
 }
 
 void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros) {
+    costmap_ros_ = costmap_ros;
+    initialize(name, costmap_ros->getCostmap(), costmap_ros->getGlobalFrameID());
+}
+
+void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap, std::string frame_id) {
     if (!initialized_) {
         ros::NodeHandle private_nh("~/" + name);
-        costmap_ros_ = costmap_ros;
-        costmap_ = costmap_ros->getCostmap();
-        frame_id_ = costmap_ros->getGlobalFrameID();
+        costmap_ = costmap;
+        frame_id_ = frame_id;
 
-        unsigned int cx = costmap_->getSizeInCellsX(), cy = costmap_->getSizeInCellsY();
+        unsigned int cx = costmap->getSizeInCellsX(), cy = costmap->getSizeInCellsY();
 
         private_nh.param("old_navfn_behavior", old_navfn_behavior_, false);
         if(!old_navfn_behavior_)
@@ -443,6 +447,8 @@ void GlobalPlanner::publishPotential(float* potential)
 
 void GlobalPlanner::showFootprintRadii() const
 {
+    if (!costmap_ros_)
+        return;
     double inscribed_radius, circumscribed_radius;
     costmap_2d::calculateMinAndMaxDistances(costmap_ros_->getRobotFootprint(), inscribed_radius, circumscribed_radius);
 


### PR DESCRIPTION
This is a partial revert of 7beb092c002d8425d5ade46442efbc65fa22e658, so please refrain from asking for refactorings or stile changes (I know the code is ma ma....) 

https://www.wrike.com/open.htm?id=1025896674