### PR TITLE
fix global planner default tolerance

### DIFF
--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -189,6 +189,11 @@ class GlobalPlanner : public mbf_costmap_core::CostmapPlanner {
         bool initialized_, allow_unknown_;
 
     private:
+        inline double sq_distance(const geometry_msgs::PoseStamped& p1, const geometry_msgs::PoseStamped& p2){
+          double dx = p1.pose.position.x - p2.pose.position.x;
+          double dy = p1.pose.position.y - p2.pose.position.y;
+          return dx*dx + dy*dy;
+        }
         void mapToWorld(double mx, double my, double& wx, double& wy);
         bool worldToMap(double wx, double wy, double& mx, double& my);
         void clearRobotCell(const geometry_msgs::PoseStamped& global_pose, unsigned int mx, unsigned int my);

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -192,7 +192,7 @@ class GlobalPlanner : public mbf_costmap_core::CostmapPlanner {
         inline double sq_distance(const geometry_msgs::PoseStamped& p1, const geometry_msgs::PoseStamped& p2){
           double dx = p1.pose.position.x - p2.pose.position.x;
           double dy = p1.pose.position.y - p2.pose.position.y;
-          return dx*dx + dy*dy;
+          return std::hypot(dx, dy);
         }
         void mapToWorld(double mx, double my, double& wx, double& wy);
         bool worldToMap(double wx, double wy, double& mx, double& my);

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -288,8 +288,8 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
       ROS_ERROR_STREAM(message);
       return mbf_msgs::GetPathResult::BLOCKED_START;
     }
-    if (costmap_->getCost(goal_x_i, goal_y_i) >= costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
-      message = "The goal pose is in collision. Planning to this pose will always fail";
+    if (tolerance == 0 && costmap_->getCost(goal_x_i, goal_y_i) >= costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
+      message = "The goal pose is in collision, and the tolerance is set to zero";
       ROS_ERROR_STREAM(message);
       return mbf_msgs::GetPathResult::BLOCKED_GOAL;
     }

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -316,11 +316,11 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
 
       double best_sdist = DBL_MAX;
 
-      p.pose.position.y = goal.pose.position.y - tolerance;
-      while(p.pose.position.y <= goal.pose.position.y + tolerance){
-        p.pose.position.x = goal.pose.position.x - tolerance;
-        while(p.pose.position.x <= goal.pose.position.x + tolerance){
-            unsigned int mx, my;
+      unsigned int mx, my;
+      for(double dy = -tolerance; dy <= tolerance; dy += resolution){
+        p.pose.position.y = goal.pose.position.y + dy;
+        const double dx = std::sqrt(tolerance*tolerance - dy*dy);
+        for(p.pose.position.x = goal.pose.position.x - dx; p.pose.position.x <= goal.pose.position.x + dx; p.pose.position.x += resolution){
             if(costmap_->worldToMap(p.pose.position.x, p.pose.position.y, mx, my)) {
               unsigned int index = my * nx + mx;
               double potential = potential_array_[index];
@@ -331,9 +331,7 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
                 found_legal = true;
               }
             }
-            p.pose.position.x += resolution;
         }
-        p.pose.position.y += resolution;
       }
 
       if (found_legal) {

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -335,11 +335,6 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
       }
 
       if (found_legal) {
-        if (!costmap_->worldToMap(best_pose.pose.position.x, best_pose.pose.position.y, goal_x_i, goal_y_i)) {
-          message = "best_pose of the global planner is off the global costmap. Planning will always fail to this goal";
-          ROS_ERROR_STREAM(message);
-          return mbf_msgs::GetPathResult::INVALID_GOAL;
-        }
         if(old_navfn_behavior_){
           goal_x = goal_x_i;
           goal_y = goal_y_i;


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1020458885

As written in the task, the `default_tolerance` parameter wasn't actually implemented in the `GlobalPlanner`; only in the `NavfnROS` planner (from which the code in the initial commit was copied).

Since our higher level components currently don't expect the robot going to a different goal than commanded, some hacks needed to be put in place to test the feature.

Note that the local planner sometimes had issues to reach the goal when it was close to an obstacle (even without this PR, that is a problem; should be dealt with by e.g. increasing the footprint padding for the global costmap, which was set to `0.01` in this test)

[This is the rr_navigation branch used for this test](https://github.com/rapyuta-robotics/rr_navigation/compare/devel...cd/test_global_planner_tolerance).

https://user-images.githubusercontent.com/4960007/209523768-eb0889f9-927f-4806-abe2-ffab777b188d.mp4


