### PR TITLE
Add parameter max_backward_dist to limit how long can the robot move backward

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_limits.h
+++ b/base_local_planner/include/base_local_planner/local_planner_limits.h
@@ -63,6 +63,7 @@ public:
   double yaw_goal_tolerance;
   double trans_stopped_vel;
   double theta_stopped_vel;
+  double max_backward_dist;
   bool   restore_defaults;
 
   LocalPlannerLimits() {}
@@ -86,7 +87,8 @@ public:
       double nyaw_goal_tolerance,
       bool   nprune_plan = true,
       double ntrans_stopped_vel = 0.1,
-      double ntheta_stopped_vel = 0.1):
+      double ntheta_stopped_vel = 0.1,
+      double nmax_backward_dist = 0.0):
         max_vel_trans(nmax_vel_trans),
         min_vel_trans(nmin_vel_trans),
         max_vel_x(nmax_vel_x),
@@ -105,7 +107,8 @@ public:
         inner_xy_goal_tolerance(ninner_xy_goal_tolerance),
         yaw_goal_tolerance(nyaw_goal_tolerance),
         trans_stopped_vel(ntrans_stopped_vel),
-        theta_stopped_vel(ntheta_stopped_vel) {}
+        theta_stopped_vel(ntheta_stopped_vel),
+        max_backward_dist(nmax_backward_dist){}
 
   ~LocalPlannerLimits() {}
 

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -42,4 +42,4 @@ def add_generic_localplanner_params(gen):
     gen.add("trans_stopped_vel", double_t, 0, "Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
     gen.add("theta_stopped_vel", double_t, 0, "Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)
 
-    gen.add("max_backward_dist", double_t, 0, "Maximum distance that the robot can travel backward before raising an error", 0.0, 0)
+    gen.add("max_backward_dist", double_t, 0, "Maximum distance that the robot can travel backward to reach the goal", 0.0, 0)

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -41,3 +41,5 @@ def add_generic_localplanner_params(gen):
 
     gen.add("trans_stopped_vel", double_t, 0, "Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
     gen.add("theta_stopped_vel", double_t, 0, "Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)
+
+    gen.add("max_backward_dist", double_t, 0, "Maximum distance that the robot can travel backward before raising an error", 0.0, 0)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -159,6 +159,8 @@ namespace dwa_local_planner {
       /// @todo: consider exposing this as a parameter
       static constexpr double MIN_GOAL_DIST_SQ = 0.7; ///< @brief Squared distance from the goal outside which the robot is encouraged to turn towards the path orientation, and within which the forward_point_distance is reduced to prevent the robot's nose from having to enter cells with cost >= INSCRIBED in order to reach the goal.
 
+      double max_backward_sq_dist_; ///< @brief Maximum distance that the robot can travel backward to reach the goal (squared to speedup computation)
+
       base_local_planner::LocalPlannerUtil *planner_util_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -167,8 +167,6 @@ namespace dwa_local_planner {
 
       void resetBestEffort();
 
-      bool backwardDistanceExceeded(const geometry_msgs::PoseStamped& robot_pose, double linear_speed);
-
       tf2_ros::Buffer* tf_; ///< @brief Used for transforming point clouds
 
       // for visualisation, publishers of global and local plan
@@ -201,8 +199,6 @@ namespace dwa_local_planner {
       bool latched_inner_goal_;
       std::vector<geometry_msgs::PoseStamped> transformed_plan_;
       boost::optional<geometry_msgs::PoseStamped> outer_goal_entry_;
-
-      boost::optional<geometry_msgs::PoseStamped> bw_motion_start_pose_;
 
       // mutex to avoid reconfigure while we're scoring trajectories
       std::mutex config_mtx_;

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -167,6 +167,8 @@ namespace dwa_local_planner {
 
       void resetBestEffort();
 
+      bool backwardDistanceExceeded(const geometry_msgs::PoseStamped& robot_pose, double linear_speed);
+
       tf2_ros::Buffer* tf_; ///< @brief Used for transforming point clouds
 
       // for visualisation, publishers of global and local plan
@@ -199,6 +201,8 @@ namespace dwa_local_planner {
       bool latched_inner_goal_;
       std::vector<geometry_msgs::PoseStamped> transformed_plan_;
       boost::optional<geometry_msgs::PoseStamped> outer_goal_entry_;
+
+      boost::optional<geometry_msgs::PoseStamped> bw_motion_start_pose_;
 
       // mutex to avoid reconfigure while we're scoring trajectories
       std::mutex config_mtx_;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,6 +85,8 @@ namespace dwa_local_planner {
     backwardvel_scale_ = 1.2 * config.sim_time * (config.path_distance_bias + config.goal_distance_bias);
     prefer_forward_costs_.setScale(backwardvel_scale_);
 
+    max_backward_sq_dist_ = std::pow(config.max_backward_dist, 2);
+
     int vx_samp, vy_samp, vth_samp;
     vx_samp = config.vx_samples;
     vy_samp = config.vy_samples;
@@ -329,7 +331,7 @@ namespace dwa_local_planner {
       path_align_costs_.setScale(1.0);
       // disable goal cost during turning because turning won't move the robot closer to the goal
       goal_costs_.setScale(0.0);
-      // disable alignment cost during turning because turning will inadvertedly move the nose off the path
+      // disable alignment cost during turning because turning will inadvertently move the nose off the path
       alignment_costs_.setScale(0.0);
 
       // retract nose
@@ -356,7 +358,7 @@ namespace dwa_local_planner {
     }
 
     // disable cost for backwards motion close to the goal
-    if (sq_dist > MIN_GOAL_DIST_SQ) {
+    if (sq_dist > max_backward_sq_dist_) {
         prefer_forward_costs_.setScale(backwardvel_scale_);
     } else {
         prefer_forward_costs_.setScale(0.0);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -85,7 +85,7 @@ namespace dwa_local_planner {
     backwardvel_scale_ = 1.2 * config.sim_time * (config.path_distance_bias + config.goal_distance_bias);
     prefer_forward_costs_.setScale(backwardvel_scale_);
 
-    max_backward_sq_dist_ = std::pow(config.max_backward_dist, 2);
+    max_backward_sq_dist_ = config.max_backward_dist * config.max_backward_dist;
 
     int vx_samp, vy_samp, vth_samp;
     vx_samp = config.vx_samples;
@@ -326,12 +326,12 @@ namespace dwa_local_planner {
 
     goal_front_costs_.setTargetPoses(front_global_plan);
 
-    if (sq_dist > MIN_GOAL_DIST_SQ && path_align_costs_.isTurningRequired()) {
+    if (sq_dist > max_backward_sq_dist_ && path_align_costs_.isTurningRequired()) {
       // enable turning penalty
       path_align_costs_.setScale(1.0);
       // disable goal cost during turning because turning won't move the robot closer to the goal
       goal_costs_.setScale(0.0);
-      // disable alignment cost during turning because turning will inadvertently move the nose off the path
+      // disable alignment cost during turning because turning will inadvertedly move the nose off the path
       alignment_costs_.setScale(0.0);
 
       // retract nose

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -92,7 +92,13 @@ namespace dwa_local_planner {
       limits.prune_plan = config.prune_plan;
       limits.trans_stopped_vel = config.trans_stopped_vel;
       limits.theta_stopped_vel = config.theta_stopped_vel;
+      limits.max_backward_dist = config.max_backward_dist;
       planner_util_.reconfigureCB(limits, config.restore_defaults);
+
+      if (config.min_vel_x < 0.0 && config.max_backward_dist == 0.0) {
+        ROS_WARN_ONCE_NAMED("dwa_local_planner", "Robot can move backward but maximum distance is 0, " \
+                                                 "so backward trajectories will be considered invalid");
+      }
 
       // update dwa specific configuration
       dp_->reconfigure(config);
@@ -190,6 +196,7 @@ namespace dwa_local_planner {
       // reset latching such that the latching doesn't apply even if the same goal is targeted again
       latchedStopRotateController_.resetLatching();
       resetBestEffort();
+      bw_motion_start_pose_.reset();
       return true;
     } else {
       return false;
@@ -429,6 +436,9 @@ namespace dwa_local_planner {
     }
 
     if (result == mbf_msgs::ExePathResult::SUCCESS) {
+      if (backwardDistanceExceeded(current_pose_, cmd_vel.twist.linear.x)) {
+        return mbf_msgs::ExePathResult::NO_VALID_CMD;
+      }
       publishGlobalPlan(transformed_plan_);
     } else {
       ROS_WARN_NAMED("dwa_local_planner", "DWA planner failed to produce path.");
@@ -439,5 +449,31 @@ namespace dwa_local_planner {
 
   }
 
+  bool DWAPlannerROS::backwardDistanceExceeded(const geometry_msgs::PoseStamped& robot_pose, double linear_speed) {
+    auto distance = [](const geometry_msgs::PoseStamped& pose1, const geometry_msgs::PoseStamped& pose2) {
+      return hypot(pose2.pose.position.x - pose1.pose.position.x, pose2.pose.position.y - pose1.pose.position.y);
+    };
 
+    // TODO: I can have a queue of speeds and only reset when all are >= 0
+    if ( ! bw_motion_start_pose_) {
+      if (linear_speed < 0.0) {  // TODO: should I use planner_util_.getCurrentLimits().min_vel_trans instead of 0?
+        bw_motion_start_pose_ = robot_pose;
+      }
+    }
+    else {
+      // we are already monitoring backward motion
+      double bw_traveled_dist = distance(bw_motion_start_pose_.value(), robot_pose);
+      if (linear_speed < 0.0) {
+        if (bw_traveled_dist > planner_util_.getCurrentLimits().max_backward_dist) {
+          ROS_WARN_NAMED("dwa_local_planner", "Robot moved backward for more than the allowed distance (%g m)",
+                         planner_util_.getCurrentLimits().max_backward_dist);
+          return true;
+        }
+      }
+      else if (linear_speed > 0.0) {
+        bw_motion_start_pose_.reset();
+      }
+    }
+    return false;
+  }
 };

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -95,11 +95,6 @@ namespace dwa_local_planner {
       limits.max_backward_dist = config.max_backward_dist;
       planner_util_.reconfigureCB(limits, config.restore_defaults);
 
-      if (config.min_vel_x < 0.0 && config.max_backward_dist == 0.0) {
-        ROS_WARN_ONCE_NAMED("dwa_local_planner", "Robot can move backward but maximum distance is 0, " \
-                                                 "so backward trajectories will be considered invalid");
-      }
-
       // update dwa specific configuration
       dp_->reconfigure(config);
   }
@@ -196,7 +191,6 @@ namespace dwa_local_planner {
       // reset latching such that the latching doesn't apply even if the same goal is targeted again
       latchedStopRotateController_.resetLatching();
       resetBestEffort();
-      bw_motion_start_pose_.reset();
       return true;
     } else {
       return false;
@@ -436,9 +430,6 @@ namespace dwa_local_planner {
     }
 
     if (result == mbf_msgs::ExePathResult::SUCCESS) {
-      if (backwardDistanceExceeded(current_pose_, cmd_vel.twist.linear.x)) {
-        return mbf_msgs::ExePathResult::NO_VALID_CMD;
-      }
       publishGlobalPlan(transformed_plan_);
     } else {
       ROS_WARN_NAMED("dwa_local_planner", "DWA planner failed to produce path.");
@@ -449,31 +440,5 @@ namespace dwa_local_planner {
 
   }
 
-  bool DWAPlannerROS::backwardDistanceExceeded(const geometry_msgs::PoseStamped& robot_pose, double linear_speed) {
-    auto distance = [](const geometry_msgs::PoseStamped& pose1, const geometry_msgs::PoseStamped& pose2) {
-      return hypot(pose2.pose.position.x - pose1.pose.position.x, pose2.pose.position.y - pose1.pose.position.y);
-    };
 
-    // TODO: I can have a queue of speeds and only reset when all are >= 0
-    if ( ! bw_motion_start_pose_) {
-      if (linear_speed < 0.0) {  // TODO: should I use planner_util_.getCurrentLimits().min_vel_trans instead of 0?
-        bw_motion_start_pose_ = robot_pose;
-      }
-    }
-    else {
-      // we are already monitoring backward motion
-      double bw_traveled_dist = distance(bw_motion_start_pose_.value(), robot_pose);
-      if (linear_speed < 0.0) {
-        if (bw_traveled_dist > planner_util_.getCurrentLimits().max_backward_dist) {
-          ROS_WARN_NAMED("dwa_local_planner", "Robot moved backward for more than the allowed distance (%g m)",
-                         planner_util_.getCurrentLimits().max_backward_dist);
-          return true;
-        }
-      }
-      else if (linear_speed > 0.0) {
-        bw_motion_start_pose_.reset();
-      }
-    }
-    return false;
-  }
 };


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1030605074

As discussed with @ayushgaud, we want to move away from DWA, so I did a rather simplistic implementation just to enable small backward motions. I open as a draft to gather some feedback, as current implementation has a couple of clear weaknesses:
- assumes there're no puntual driving direction changes (rather reasonable)
- fails when bypassing `max_backward_dist` instead simply don't allow any further backward motion. The reasons for these are
  - much simpler and chirurgical implementation
  - avoid oscillations once we reach `max_backward_dist` (that is, move a bit FW, re-enable BW motion, move a bit BW etc). Sure, we can prevent this by ratcheting the backward travelled distance, but again, that makes the change even more complicated