### PR TITLE
dwa planner: tolerance from action quick and dirty

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -181,6 +181,7 @@ namespace dwa_local_planner {
 
       dynamic_reconfigure::Server<DWAPlannerConfig> *dsrv_;
       dwa_local_planner::DWAPlannerConfig default_config_;
+      base_local_planner::LocalPlannerLimits _latest_limits; ///< @brief latest limits set by dynamic reconfigure
       bool setup_;
       geometry_msgs::PoseStamped current_pose_;
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -136,10 +136,11 @@ namespace dwa_local_planner {
 
       /**
        * @brief  Check if the goal pose has been achieved.
-       * The arguments are required by MBF controller API, but are ignored.
+       * @param dist_tolerance The distance tolerance in which the current pose will be partly accepted as reached goal
+       * @param angle_tolerance The angle tolerance in which the current pose will be partly accepted as reached goal
        * @return True if achieved, false otherwise
        */
-      bool isGoalReached(double, double);
+      bool isGoalReached(double dist_tolerance, double angle_tolerance);
 
       /**
        * @brief Requests the planner to cancel; not implemented for this planner

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -136,8 +136,25 @@ namespace dwa_local_planner {
 
       /**
        * @brief  Check if the goal pose has been achieved.
-       * @param dist_tolerance The distance tolerance in which the current pose will be partly accepted as reached goal
-       * @param angle_tolerance The angle tolerance in which the current pose will be partly accepted as reached goal
+       * Notes about which tolerances are used for checking whether the robot reached the goal, depending on the ExePathActionGoal:
+       * - the DWA planner's internal xy_goal_tolerance are used if in the ExePathActionGoal:
+       *   - tolerance_from_action: true
+       *   - dist_tolerance: <=0
+       * - the DWA planner's internal yaw_goal_tolerance are used if in the ExePathActionGoal:
+       *   - tolerance_from_action: true
+       *   - angle_tolerance: <=0
+       * - the dist_tolerance of ExePathActionGoal is used if in the ExePathActionGoal:
+       *   - tolerance_from_action: true
+       *   - dist_tolerance: >0
+       * - the angle_tolerance of ExePathActionGoal is used if in the ExePathActionGoal:
+       *   - tolerance_from_action: true
+       *   - angle_tolerance: >0
+       * - the dist_tolerance and angle_tolerance ROS parameters of move_base_flex are used if in the ExePathActionGoal:
+       *   - tolerance_from_action: false
+       * @param dist_tolerance The distance tolerance in which the current pose will be partly accepted as reached goal.
+       *                       If dist_tolerance is set to <=0, the xy_goal_tolerance parameter is used instead.
+       * @param angle_tolerance The angle tolerance in which the current pose will be partly accepted as reached goal.
+       *                        If angle_tolerance is set to <=0, the yaw_goal_tolerance parameter is used instead.
        * @return True if achieved, false otherwise
        */
       bool isGoalReached(double dist_tolerance, double angle_tolerance) override;

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -78,7 +78,7 @@ namespace dwa_local_planner {
        * @param costmap The cost map to use for assigning costs to trajectories
        */
       void initialize(std::string name, tf2_ros::Buffer* tf,
-          costmap_2d::Costmap2DROS* costmap_ros);
+          costmap_2d::Costmap2DROS* costmap_ros) override;
 
       /**
        * @brief  Destructor for the wrapper
@@ -114,7 +114,7 @@ namespace dwa_local_planner {
        */
       uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                        const geometry_msgs::TwistStamped& velocity,
-                                       geometry_msgs::TwistStamped& cmd_vel, std::string& message);
+                                       geometry_msgs::TwistStamped& cmd_vel, std::string& message) override;
 
       /**
        * @brief  Given the current position, orientation, and velocity of the robot,
@@ -132,7 +132,7 @@ namespace dwa_local_planner {
        * @param orig_global_plan The plan to pass to the controller
        * @return True if the plan was updated successfully, false otherwise
        */
-      bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
+      bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan) override;
 
       /**
        * @brief  Check if the goal pose has been achieved.
@@ -140,13 +140,13 @@ namespace dwa_local_planner {
        * @param angle_tolerance The angle tolerance in which the current pose will be partly accepted as reached goal
        * @return True if achieved, false otherwise
        */
-      bool isGoalReached(double dist_tolerance, double angle_tolerance);
+      bool isGoalReached(double dist_tolerance, double angle_tolerance) override;
 
       /**
        * @brief Requests the planner to cancel; not implemented for this planner
        * @return True if a cancel has been successfully requested, false if not implemented.
        */
-      bool cancel() { return false; };
+      bool cancel() override { return false; };
 
       bool isInitialized() {
         return initialized_;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -191,9 +191,13 @@ namespace dwa_local_planner {
       std::lock_guard<std::mutex> lock(config_mtx_);
       auto limits = planner_util_.getCurrentLimits();
       if (dist_tolerance > 0) {
+        ROS_INFO_STREAM_COND(dist_tolerance != limits.xy_goal_tolerance,
+            "updating xy_goal_tolerance to tolerance from action: " << dist_tolerance);
         limits.xy_goal_tolerance = dist_tolerance;
       }
       if (angle_tolerance > 0) {
+        ROS_INFO_STREAM_COND(angle_tolerance != limits.yaw_goal_tolerance,
+            "updating yaw_goal_tolerance to tolerance from action: " << angle_tolerance);
         limits.yaw_goal_tolerance = angle_tolerance;
       }
       planner_util_.reconfigureCB(limits, false);


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1032661274

This is a quick implementation to use the tolerances from the action (if they're larger than 0, just like in the [path_follower](https://github.com/rapyuta-robotics/rr_navigation/blob/devel/rr_nav_path_follower/src/path_follower_ros.cpp#L153)). Since these tolerances are used all over the place, the easiest was to just update the limits such that all the places that use `planner_util_.getCurrentLimits()` use the correct values.

for more context, see https://github.com/rapyuta-robotics/rr_navigation/pull/1283