### PR TITLE
prevent interpolation from modifying the orientation of the start and end

### DIFF
--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -156,7 +156,7 @@ void OrientationFilter::interpolate(std::vector<geometry_msgs::PoseStamped>& pat
                  end_yaw   = tf2::getYaw(path[end_index  ].pose.orientation);
     double diff = angles::shortest_angular_distance(start_yaw, end_yaw);
     double increment = diff/(end_index-start_index);
-    for(int i=start_index; i<=end_index; i++){
+    for(int i=start_index+1; i<end_index; i++){
         double angle = start_yaw + increment * i;
         set_angle(&path[i], angle);
     }


### PR DESCRIPTION
Issue traced down with @renan028 on why sometimes that the global planner's path's last pose is (slightly) different from the goal sent in the GetPath action: The issue was that the orientation interpolation changed it (even though this isn't necessary)

Once this is fixed, this other PR can be reviewed / merged: https://github.com/rapyuta-robotics/rr_navigation/pull/1307