### PR TITLE
dwa planner: select goal which is not in collision

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_limits.h
+++ b/base_local_planner/include/base_local_planner/local_planner_limits.h
@@ -60,7 +60,9 @@ public:
   bool   prune_plan;
   double xy_goal_tolerance;
   double inner_xy_goal_tolerance;
+  double xy_min_goal_tolerance;
   double yaw_goal_tolerance;
+  double blocked_goal_approach_distance;
   double trans_stopped_vel;
   double theta_stopped_vel;
   double max_backward_dist;
@@ -84,7 +86,9 @@ public:
       double nacc_lim_trans,
       double nxy_goal_tolerance,
       double ninner_xy_goal_tolerance,
+      double nxy_min_goal_tolerance,
       double nyaw_goal_tolerance,
+      double nblocked_goal_approach_distance,
       bool   nprune_plan = true,
       double ntrans_stopped_vel = 0.1,
       double ntheta_stopped_vel = 0.1,
@@ -105,7 +109,9 @@ public:
         prune_plan(nprune_plan),
         xy_goal_tolerance(nxy_goal_tolerance),
         inner_xy_goal_tolerance(ninner_xy_goal_tolerance),
+        xy_min_goal_tolerance(nxy_min_goal_tolerance),
         yaw_goal_tolerance(nyaw_goal_tolerance),
+        blocked_goal_approach_distance(nblocked_goal_approach_distance),
         trans_stopped_vel(ntrans_stopped_vel),
         theta_stopped_vel(ntheta_stopped_vel),
         max_backward_dist(nmax_backward_dist){}

--- a/base_local_planner/include/base_local_planner/local_planner_limits.h
+++ b/base_local_planner/include/base_local_planner/local_planner_limits.h
@@ -62,7 +62,7 @@ public:
   double inner_xy_goal_tolerance;
   double xy_min_goal_tolerance;
   double yaw_goal_tolerance;
-  double blocked_goal_approach_distance;
+  double goal_obstacle_approach_distance;
   double trans_stopped_vel;
   double theta_stopped_vel;
   double max_backward_dist;
@@ -88,7 +88,7 @@ public:
       double ninner_xy_goal_tolerance,
       double nxy_min_goal_tolerance,
       double nyaw_goal_tolerance,
-      double nblocked_goal_approach_distance,
+      double ngoal_obstacle_approach_distance,
       bool   nprune_plan = true,
       double ntrans_stopped_vel = 0.1,
       double ntheta_stopped_vel = 0.1,
@@ -111,7 +111,7 @@ public:
         inner_xy_goal_tolerance(ninner_xy_goal_tolerance),
         xy_min_goal_tolerance(nxy_min_goal_tolerance),
         yaw_goal_tolerance(nyaw_goal_tolerance),
-        blocked_goal_approach_distance(nblocked_goal_approach_distance),
+        goal_obstacle_approach_distance(ngoal_obstacle_approach_distance),
         trans_stopped_vel(ntrans_stopped_vel),
         theta_stopped_vel(ntheta_stopped_vel),
         max_backward_dist(nmax_backward_dist){}

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -37,10 +37,10 @@ def add_generic_localplanner_params(gen):
 
     gen.add("xy_goal_tolerance", double_t, 0, "Within what maximum distance we consider the robot to be in goal", 0.1)
     gen.add("inner_xy_goal_tolerance", double_t, 0, "Best effort distance for the robot to reach the goal", 0.1)
-    gen.add("xy_min_goal_tolerance", double_t, 0, "minimum tolerance needed to reliably reach a goal; if the goal is within an obstacle, the goal can be displaced by (xy_goal_tolerance - xy_min_goal_tolerance)", 0.1)
+    gen.add("xy_min_goal_tolerance", double_t, 0, "Minimum tolerance needed to reliably reach a goal; if the goal is within an obstacle, the goal can be displaced by (xy_goal_tolerance - xy_min_goal_tolerance)", 0.1)
     gen.add("yaw_goal_tolerance", double_t, 0, "Within what maximum angle difference we consider the robot to face goal direction", 0.1)
 
-    gen.add("goal_obstacle_approach_distance", double_t, 0, "Even if the goal is blocked, the goal is approached until this distance", 1.0)
+    gen.add("goal_obstacle_approach_distance", double_t, 0, "In case the goal is blocked, move towards it until the obstacle blocking the goal is within this distance", 1.0)
 
     gen.add("trans_stopped_vel", double_t, 0, "Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
     gen.add("theta_stopped_vel", double_t, 0, "Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -37,7 +37,10 @@ def add_generic_localplanner_params(gen):
 
     gen.add("xy_goal_tolerance", double_t, 0, "Within what maximum distance we consider the robot to be in goal", 0.1)
     gen.add("inner_xy_goal_tolerance", double_t, 0, "Best effort distance for the robot to reach the goal", 0.1)
+    gen.add("xy_min_goal_tolerance", double_t, 0, "minimum tolerance needed to reliably reach a goal; if the goal is within an obstacle, the goal can be displaced by (xy_goal_tolerance - xy_min_goal_tolerance)", 0.1)
     gen.add("yaw_goal_tolerance", double_t, 0, "Within what maximum angle difference we consider the robot to face goal direction", 0.1)
+
+    gen.add("blocked_goal_approach_distance", double_t, 0, "Even if the goal is blocked, the goal is approached until this distance", 1.0)
 
     gen.add("trans_stopped_vel", double_t, 0, "Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
     gen.add("theta_stopped_vel", double_t, 0, "Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -40,7 +40,7 @@ def add_generic_localplanner_params(gen):
     gen.add("xy_min_goal_tolerance", double_t, 0, "minimum tolerance needed to reliably reach a goal; if the goal is within an obstacle, the goal can be displaced by (xy_goal_tolerance - xy_min_goal_tolerance)", 0.1)
     gen.add("yaw_goal_tolerance", double_t, 0, "Within what maximum angle difference we consider the robot to face goal direction", 0.1)
 
-    gen.add("blocked_goal_approach_distance", double_t, 0, "Even if the goal is blocked, the goal is approached until this distance", 1.0)
+    gen.add("goal_obstacle_approach_distance", double_t, 0, "Even if the goal is blocked, the goal is approached until this distance", 1.0)
 
     gen.add("trans_stopped_vel", double_t, 0, "Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
     gen.add("theta_stopped_vel", double_t, 0, "Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -167,7 +167,7 @@ namespace dwa_local_planner {
 
     private:
       /**
-       * @brief crop a plan such that the last pose is a reachable (i.e. footprint not in collision)
+       * @brief crop a plan such that the last pose is reachable (i.e. footprint not in collision)
        * @param global_pose The robot's current pose
        * @param footprint_spec The robot's footprint
        * @param plan global plan that is being modified

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -82,6 +82,15 @@ namespace dwa_local_planner {
       DWAPlanner(std::string name, base_local_planner::LocalPlannerUtil *planner_util);
 
       /**
+       * @brief  Destructor for the planner
+       */
+      ~DWAPlanner() {
+        if (world_model_ != NULL) {
+          delete world_model_;
+        }
+      }
+
+      /**
        * @brief Reconfigures the trajectory planner
        */
       void reconfigure(DWAPlannerConfig &cfg);
@@ -115,13 +124,14 @@ namespace dwa_local_planner {
        * @param  global_pose The robot's current pose
        * @param  new_plan The new global plan
        * @param  footprint_spec The robot's footprint
+       * @return ExePath action result code
        *
        * The obstacle cost function gets the footprint.
        * The path and goal cost functions get the global_plan
        * The alignment cost functions get a version of the global plan
        *   that is modified based on the global_pose
        */
-      void updatePlanAndLocalCosts(const geometry_msgs::PoseStamped& global_pose,
+      uint32_t updatePlanAndLocalCosts(const geometry_msgs::PoseStamped& global_pose,
           const std::vector<geometry_msgs::PoseStamped>& new_plan,
           const std::vector<geometry_msgs::Point>& footprint_spec);
 
@@ -156,12 +166,25 @@ namespace dwa_local_planner {
       std::vector<geometry_msgs::Point> getScaledFootprint(const base_local_planner::Trajectory &traj) const;
 
     private:
+      /**
+       * @brief crop a plan such that the last pose is a reachable (i.e. footprint not in collision)
+       * @param global_pose The robot's current pose
+       * @param footprint_spec The robot's footprint
+       * @param plan global plan that is being modified
+       * @return ExePath action result code
+       */
+      uint32_t cropPlanToReachableGoal(
+        const geometry_msgs::PoseStamped& global_pose,
+        const std::vector<geometry_msgs::Point>& footprint_spec,
+        std::vector<geometry_msgs::PoseStamped>& plan);
+
       /// @todo: consider exposing this as a parameter
       static constexpr double MIN_GOAL_DIST_SQ = 0.7; ///< @brief Squared distance from the goal outside which the robot is encouraged to turn towards the path orientation, and within which the forward_point_distance is reduced to prevent the robot's nose from having to enter cells with cost >= INSCRIBED in order to reach the goal.
 
       double max_backward_sq_dist_; ///< @brief Maximum distance that the robot can travel backward to reach the goal (squared to speedup computation)
 
       base_local_planner::LocalPlannerUtil *planner_util_;
+      base_local_planner::WorldModel* world_model_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop
       double path_distance_bias_, goal_distance_bias_, occdist_scale_, backwardvel_scale_;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -301,7 +301,7 @@ namespace dwa_local_planner {
 
     const auto dist_to_last_free_point = mbf_utility::distance(global_pose, plan[last_point_in_free_space]);
     const auto limits = planner_util_->getCurrentLimits();
-    if (dist_to_last_free_point > limits.blocked_goal_approach_distance) {
+    if (dist_to_last_free_point > limits.goal_obstacle_approach_distance) {
       // -> just crop the path to this point
       plan.resize(last_point_in_free_space+1);
       return mbf_msgs::ExePathResult::SUCCESS;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -381,7 +381,7 @@ namespace dwa_local_planner {
     const auto cos_angle_to_goal = cos(angle_to_goal);
     const auto sin_angle_to_goal = sin(angle_to_goal);
     const auto sq_dist = dist_to_goal * dist_to_goal;
-    if (sq_dist * sq_dist < MIN_GOAL_DIST_SQ) {
+    if (sq_dist < MIN_GOAL_DIST_SQ) {
       // when close to the goal, reduce forward_point_distance such that the robot can reach the goal pose
       // without its nose entering space considered as occupied by obstacles
       forward_point_distance = 0;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -48,6 +48,9 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 
+#include <mbf_msgs/ExePathResult.h>
+#include <mbf_utility/navigation_utility.h>
+
 namespace dwa_local_planner {
   void DWAPlanner::reconfigure(DWAPlannerConfig &config)
   {
@@ -183,6 +186,10 @@ namespace dwa_local_planner {
     scored_sampling_planner_ = base_local_planner::SimpleScoredSamplingPlanner(generator_list, critics);
 
     private_nh.param("cheat_factor", cheat_factor_, 1.0);
+
+    if (planner_util->getCostmap() != NULL) {
+      world_model_ = new base_local_planner::CostmapModel(*planner_util->getCostmap());
+    }
   }
 
   // used for visualization only, total_costs are not really total costs
@@ -252,8 +259,56 @@ namespace dwa_local_planner {
     return false;
   }
 
+  uint32_t DWAPlanner::cropPlanToReachableGoal(
+    const geometry_msgs::PoseStamped& global_pose,
+    const std::vector<geometry_msgs::Point>& footprint_spec,
+    std::vector<geometry_msgs::PoseStamped>& plan) {
+    // search the path for a reachable goal
+    const double dist_to_goal = mbf_utility::distance(global_pose, plan.back());
 
-  void DWAPlanner::updatePlanAndLocalCosts(
+    const double goal_yaw = tf2::getYaw(global_pose.pose.orientation);
+    const double xy_goal_tolerance = planner_util_->getCurrentLimits().xy_goal_tolerance;
+    const double min_tolerance_for_reaching_goal = 0.03;
+    const double max_goal_deviation = std::max(0.0, xy_goal_tolerance - min_tolerance_for_reaching_goal);
+    bool reachable_goal_found = false;
+    bool footprint_on_any_path_point_completely_on_map = false;
+    auto i = static_cast<int>(plan.size()) - 1;
+    for (; i >= 0; --i) {
+      const auto dist_to_goal = mbf_utility::distance(plan[i], plan.back());
+      if (dist_to_goal > max_goal_deviation) {
+        break;
+      }
+      const auto footprint_cost = world_model_->footprintCost(plan[i].pose.position.x, plan[i].pose.position.y, goal_yaw, footprint_spec);
+      reachable_goal_found = footprint_cost >= 0;
+      footprint_on_any_path_point_completely_on_map = footprint_cost != -3;
+      if (reachable_goal_found) {
+        break;
+      }
+    }
+
+    if (!footprint_on_any_path_point_completely_on_map) {
+      ROS_WARN_STREAM("Part of the footprint is in out of map for all path points");
+      return mbf_msgs::ExePathResult::OUT_OF_MAP;
+    }
+
+    if (!reachable_goal_found) {
+      if (dist_to_goal < 1) {
+        ROS_WARN_STREAM("The footprint is in collision for all path points within " << max_goal_deviation << "[m] of the goal");
+        return mbf_msgs::ExePathResult::BLOCKED_GOAL;
+      }
+
+      if (i < 0) {
+        // this seems unlikely, but needs to be handled
+        ROS_WARN_STREAM("The footprint is in collision for all path points");
+        return mbf_msgs::ExePathResult::BLOCKED_PATH;
+      }
+    }
+
+    plan.resize(i+1);
+    return mbf_msgs::ExePathResult::SUCCESS;
+  }
+
+  uint32_t DWAPlanner::updatePlanAndLocalCosts(
       const geometry_msgs::PoseStamped& global_pose,
       const std::vector<geometry_msgs::PoseStamped>& new_plan,
       const std::vector<geometry_msgs::Point>& footprint_spec) {
@@ -262,37 +317,40 @@ namespace dwa_local_planner {
       global_plan_[i] = new_plan[i];
     }
 
+    std::vector<geometry_msgs::PoseStamped> front_global_plan = global_plan_;
+    const auto result = cropPlanToReachableGoal(global_pose, footprint_spec, front_global_plan);
+    if (result != mbf_msgs::ExePathResult::SUCCESS) {
+      return result;
+    }
+
+    const geometry_msgs::PoseStamped goal_pose = front_global_plan.back();
+    const double dist_to_goal = mbf_utility::distance(global_pose, goal_pose);
+
     obstacle_costs_.setFootprint(footprint_spec);
 
     path_align_costs_.setTargetPoses(global_plan_, global_pose);
 
     // costs for going away from path
-    path_costs_.setTargetPoses(global_plan_);
-    alignment_costs_.setTargetPoses(global_plan_);
+    path_costs_.setTargetPoses(front_global_plan);
+    alignment_costs_.setTargetPoses(front_global_plan);
 
     // costs for not going towards the local goal as much as possible
-    goal_costs_.setTargetPoses(global_plan_);
+    goal_costs_.setTargetPoses(front_global_plan);
 
     // alignment costs
-    geometry_msgs::PoseStamped goal_pose = global_plan_.back();
-
-    Eigen::Vector3f pos(global_pose.pose.position.x, global_pose.pose.position.y, tf2::getYaw(global_pose.pose.orientation));
-    double sq_dist =
-        (pos[0] - goal_pose.pose.position.x) * (pos[0] - goal_pose.pose.position.x) +
-        (pos[1] - goal_pose.pose.position.y) * (pos[1] - goal_pose.pose.position.y);
 
     // we want the robot nose to be drawn to its final position
     // (before robot turns towards goal orientation), not the end of the
     // path for the robot center. Choosing the final position after
     // turning towards goal orientation causes instability when the
     // robot needs to make a 180 degree turn at the end
-    std::vector<geometry_msgs::PoseStamped> front_global_plan = global_plan_;
-    double angle_to_goal = atan2(goal_pose.pose.position.y - pos[1], goal_pose.pose.position.x - pos[0]);
+    double angle_to_goal = atan2(goal_pose.pose.position.y - global_pose.pose.position.y, goal_pose.pose.position.x - global_pose.pose.position.x);
 
     double forward_point_distance = forward_point_distance_;
     const auto cos_angle_to_goal = cos(angle_to_goal);
     const auto sin_angle_to_goal = sin(angle_to_goal);
-    if (sq_dist < MIN_GOAL_DIST_SQ) {
+    const auto sq_dist = dist_to_goal * dist_to_goal;
+    if (sq_dist * sq_dist < MIN_GOAL_DIST_SQ) {
       // when close to the goal, reduce forward_point_distance such that the robot can reach the goal pose
       // without its nose entering space considered as occupied by obstacles
       forward_point_distance = 0;
@@ -363,8 +421,8 @@ namespace dwa_local_planner {
     } else {
         prefer_forward_costs_.setScale(0.0);
     }
+    return mbf_msgs::ExePathResult::SUCCESS;
   }
-
 
   /*
    * given the current state of the robot, find a good trajectory

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -266,12 +266,52 @@ namespace dwa_local_planner {
     // search the path for a reachable goal
     const double dist_to_goal = mbf_utility::distance(global_pose, plan.back());
 
-    const double goal_yaw = tf2::getYaw(global_pose.pose.orientation);
+    // find furthest point along the path of which the corresponding cell is in free space
+    const costmap_2d::Costmap2D* const costmap = planner_util_->getCostmap();
+    int last_point_on_the_map = -1;
+    int last_point_in_free_space = -1;
+    for (unsigned int i = 0; i < plan.size(); ++i) {
+      double g_x = plan[i].pose.position.x;
+      double g_y = plan[i].pose.position.y;
+      unsigned int map_x, map_y;
+      if (!costmap->worldToMap(g_x, g_y, map_x, map_y)) {
+        // give up once a point within the map had been found
+        if (last_point_on_the_map >= 0) {
+          break;
+        }
+        continue;
+      }
+
+      last_point_on_the_map = i;
+      if (costmap->getCost(map_x, map_y) < costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
+        last_point_in_free_space = i;
+      }
+    }
+
+    // handle general errors
+    if (last_point_on_the_map == -1) {
+      ROS_ERROR("None of the points of the global plan were in the local costmap, global plan points too far from robot");
+      return mbf_msgs::ExePathResult::OUT_OF_MAP;
+    }
+
+    if (last_point_in_free_space == -1) {
+      ROS_ERROR("None of the points of the global plan were in free space");
+      return mbf_msgs::ExePathResult::BLOCKED_PATH;
+    }
+
+    const auto dist_to_last_free_point = mbf_utility::distance(global_pose, plan[last_point_in_free_space]);
     const auto limits = planner_util_->getCurrentLimits();
+    if (dist_to_last_free_point > limits.blocked_goal_approach_distance) {
+      // -> just crop the path to this point
+      plan.resize(last_point_in_free_space+1);
+      return mbf_msgs::ExePathResult::SUCCESS;
+    }
+
+    // check if any path point close to the goal is reachable
+    const double goal_yaw = tf2::getYaw(global_pose.pose.orientation);
     const double max_goal_deviation = std::max(0.0, limits.xy_goal_tolerance - limits.xy_min_goal_tolerance);
     bool reachable_goal_found = false;
-    bool footprint_on_any_path_point_completely_on_map = false;
-    auto i = static_cast<int>(plan.size()) - 1;
+    auto i = last_point_in_free_space;
     for (; i >= 0; --i) {
       const auto dist_to_goal = mbf_utility::distance(plan[i], plan.back());
       if (dist_to_goal > max_goal_deviation) {
@@ -279,28 +319,20 @@ namespace dwa_local_planner {
       }
       const auto footprint_cost = world_model_->footprintCost(plan[i].pose.position.x, plan[i].pose.position.y, goal_yaw, footprint_spec);
       reachable_goal_found = footprint_cost >= 0;
-      footprint_on_any_path_point_completely_on_map = footprint_cost != -3;
       if (reachable_goal_found) {
         break;
       }
     }
 
-    if (!footprint_on_any_path_point_completely_on_map) {
-      ROS_WARN_STREAM("Part of the footprint is in out of map for all path points");
-      return mbf_msgs::ExePathResult::OUT_OF_MAP;
+    if (!reachable_goal_found) {
+      ROS_WARN_STREAM("The footprint is in collision for all path points within " << max_goal_deviation << "[m] of the goal");
+      return mbf_msgs::ExePathResult::BLOCKED_GOAL;
     }
 
-    if (!reachable_goal_found) {
-      if (dist_to_goal < limits.blocked_goal_approach_distance) {
-        ROS_WARN_STREAM("The footprint is in collision for all path points within " << max_goal_deviation << "[m] of the goal");
-        return mbf_msgs::ExePathResult::BLOCKED_GOAL;
-      }
-
-      if (i < 0) {
-        // this seems unlikely, but needs to be handled
-        ROS_WARN_STREAM("The footprint is in collision for all path points");
-        return mbf_msgs::ExePathResult::BLOCKED_PATH;
-      }
+    if (i < 0) {
+      // this seems unlikely, but needs to be handled
+      ROS_WARN_STREAM("The footprint is in collision for all path points");
+      return mbf_msgs::ExePathResult::BLOCKED_PATH;
     }
 
     plan.resize(i+1);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -267,9 +267,8 @@ namespace dwa_local_planner {
     const double dist_to_goal = mbf_utility::distance(global_pose, plan.back());
 
     const double goal_yaw = tf2::getYaw(global_pose.pose.orientation);
-    const double xy_goal_tolerance = planner_util_->getCurrentLimits().xy_goal_tolerance;
-    const double min_tolerance_for_reaching_goal = 0.03;
-    const double max_goal_deviation = std::max(0.0, xy_goal_tolerance - min_tolerance_for_reaching_goal);
+    const auto limits = planner_util_->getCurrentLimits();
+    const double max_goal_deviation = std::max(0.0, limits.xy_goal_tolerance - limits.xy_min_goal_tolerance);
     bool reachable_goal_found = false;
     bool footprint_on_any_path_point_completely_on_map = false;
     auto i = static_cast<int>(plan.size()) - 1;
@@ -292,7 +291,7 @@ namespace dwa_local_planner {
     }
 
     if (!reachable_goal_found) {
-      if (dist_to_goal < 1) {
+      if (dist_to_goal < limits.blocked_goal_approach_distance) {
         ROS_WARN_STREAM("The footprint is in collision for all path points within " << max_goal_deviation << "[m] of the goal");
         return mbf_msgs::ExePathResult::BLOCKED_GOAL;
       }

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -308,7 +308,7 @@ namespace dwa_local_planner {
     }
 
     // check if any path point close to the goal is reachable
-    const double goal_yaw = tf2::getYaw(global_pose.pose.orientation);
+    const double goal_yaw = tf2::getYaw(plan.back().pose.orientation);
     const double max_goal_deviation = std::max(0.0, limits.xy_goal_tolerance - limits.xy_min_goal_tolerance);
     bool reachable_goal_found = false;
     auto i = last_point_in_free_space;
@@ -331,7 +331,7 @@ namespace dwa_local_planner {
 
     if (i < 0) {
       // this seems unlikely, but needs to be handled
-      ROS_WARN_STREAM("The footprint is in collision for all path points");
+      ROS_WARN("The footprint is in collision for all path points");
       return mbf_msgs::ExePathResult::BLOCKED_PATH;
     }
 

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -302,12 +302,17 @@ namespace dwa_local_planner {
     const auto dist_to_last_free_point = mbf_utility::distance(global_pose, plan[last_point_in_free_space]);
     const auto limits = planner_util_->getCurrentLimits();
     if (dist_to_last_free_point > limits.goal_obstacle_approach_distance) {
-      // -> just crop the path to this point
+      // If the obstacle blocking the goal is further than goal_obstacle_approach_distance,
+      // just target the last free point instead, by cropping the path to that point.
+
+      // The reasoning for going towards the goal even though it is blocked by an obstacle according to the costmap
+      // is to ensure that the goal is actually still blocked (i.e. not because of some left-over obstacle from some earlier time)
       plan.resize(last_point_in_free_space+1);
       return mbf_msgs::ExePathResult::SUCCESS;
     }
 
-    // check if any path point close to the goal is reachable
+    // goal / obstacle blocking the goal is within goal_obstacle_approach_distance
+    // -> check if any path point close to the goal is reachable (i.e. can fit robot footprint without colliding)
     const double goal_yaw = tf2::getYaw(plan.back().pose.orientation);
     const double max_goal_deviation = std::max(0.0, limits.xy_goal_tolerance - limits.xy_min_goal_tolerance);
     bool reachable_goal_found = false;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -414,7 +414,12 @@ namespace dwa_local_planner {
     ROS_DEBUG_NAMED("dwa_local_planner", "Received a transformed plan with %zu points.", transformed_plan_.size());
 
     // update plan in dwa_planner even if we just stop and rotate, to allow checkTrajectory
-    dp_->updatePlanAndLocalCosts(current_pose_, transformed_plan_, costmap_ros_->getRobotFootprint());
+    const auto goal_found = dp_->updatePlanAndLocalCosts(current_pose_, transformed_plan_, costmap_ros_->getRobotFootprint());
+    if (goal_found != mbf_msgs::ExePathResult::SUCCESS) {
+      message = "No reachable goal could be found";
+      ROS_ERROR_STREAM_NAMED("dwa_local_planner", message);
+      return goal_found;
+    }
 
     // check if we reached outer tolerance
     const bool reached_outer_goal = latchedStopRotateController_.isPositionReached(&planner_util_, current_pose_);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -90,7 +90,7 @@ namespace dwa_local_planner {
       _latest_limits.inner_xy_goal_tolerance = config.inner_xy_goal_tolerance;
       _latest_limits.xy_min_goal_tolerance = config.xy_min_goal_tolerance;
       _latest_limits.yaw_goal_tolerance = config.yaw_goal_tolerance;
-      _latest_limits.blocked_goal_approach_distance = config.blocked_goal_approach_distance;
+      _latest_limits.goal_obstacle_approach_distance = config.goal_obstacle_approach_distance;
       _latest_limits.prune_plan = config.prune_plan;
       _latest_limits.trans_stopped_vel = config.trans_stopped_vel;
       _latest_limits.theta_stopped_vel = config.theta_stopped_vel;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -88,7 +88,9 @@ namespace dwa_local_planner {
       _latest_limits.acc_lim_trans = config.acc_lim_trans;
       _latest_limits.xy_goal_tolerance = config.xy_goal_tolerance;
       _latest_limits.inner_xy_goal_tolerance = config.inner_xy_goal_tolerance;
+      _latest_limits.xy_min_goal_tolerance = config.xy_min_goal_tolerance;
       _latest_limits.yaw_goal_tolerance = config.yaw_goal_tolerance;
+      _latest_limits.blocked_goal_approach_distance = config.blocked_goal_approach_distance;
       _latest_limits.prune_plan = config.prune_plan;
       _latest_limits.trans_stopped_vel = config.trans_stopped_vel;
       _latest_limits.theta_stopped_vel = config.theta_stopped_vel;


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1059884980

## Description

As discussed in the meeting last Tuesday, this is the simplest implementation to handle goal tolerances in the DWA planner + ensuring that the robot's footprint can be placed at the goal.

If the goal is in collision and not too far away, an alternative goal is selected by trying to fit the footprint onto a path point before the goal, with the goal yaw.

Note: a bunch of features that were added earlier (https://github.com/rapyuta-robotics/ros-navigation/pull/56 and https://github.com/rapyuta-robotics/ros-navigation/pull/66) could probably be removed as I think they're now redundant.

## Testing

To make global planner succeed, but local planner poses be in obstacles, I increased the footprint padding in the local costmap. I also set the xy tolerance to 0.5m.

Scenario 1: Goal is in an obstacle -> goal can now be reached

https://user-images.githubusercontent.com/4960007/221152956-baf9e504-d897-4061-8135-bd7a3f06d3f1.mp4

Scenario 2: Goal in a place where the footprint can fit on the goal orientation -> goal can still be reached

https://user-images.githubusercontent.com/4960007/221153137-42511936-3f33-4eb6-9ad1-8fb9312cac9c.mp4

Scenario 3: Goal in a place the robot can reach, but goal orientation cannot be reached -> reports "Blocked Goal

https://user-images.githubusercontent.com/4960007/221153396-70771890-dc5b-4f1a-b8b1-6d19644e68e3.mp4


