### PR TITLE
reset move base flex ci branch to master

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: 'ros-industrial/industrial_ci@master'
-        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: 'github:magazino/move_base_flex#js/add_error_codes -move_base_flex/mbf_abstract_core -move_base_flex/mbf_abstract_nav -move_base_flex/mbf_costmap_core -move_base_flex/mbf_costmap_nav -move_base_flex/mbf_simple_nav'}
+        env: {ROS_DISTRO: noetic, ROS_REPO: main, UPSTREAM_WORKSPACE: 'github:magazino/move_base_flex#master -move_base_flex/mbf_abstract_core -move_base_flex/mbf_abstract_nav -move_base_flex/mbf_costmap_core -move_base_flex/mbf_costmap_nav -move_base_flex/mbf_simple_nav'}


### PR DESCRIPTION
Note that the error codes were [merged to master](https://github.com/magazino/move_base_flex/commit/d82c57311f8bc817bfdf8a7e01c0e5aaa4d71cde), we can change the CI back to using the master branch