### PR TITLE
Print warning when layer to clear doesn't exist

### DIFF
--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -142,7 +142,7 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
   double x = pose.pose.position.x;
   double y = pose.pose.position.y;
 
-  std::unordered_set<std::string> cleared_layers;
+  std::unordered_set<std::string> found_layers;
 
   for (std::vector<boost::shared_ptr<costmap_2d::Layer> >::iterator pluginp = plugins->begin(); pluginp != plugins->end(); ++pluginp) {
     boost::shared_ptr<costmap_2d::Layer> plugin = *pluginp;
@@ -154,7 +154,7 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
 
     if(clearable_layers_.count(name)!=0){
 
-      cleared_layers.insert(name);
+      found_layers.insert(name);
 
       // check if the value is convertable
       if(!dynamic_cast<costmap_2d::CostmapLayer*>(plugin.get())){
@@ -169,9 +169,7 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
   }
 
   for (const auto& layer : clearable_layers_) {
-    if (!cleared_layers.count(layer)) {
-      ROS_WARN_STREAM("Cannot clear layer " << layer << " because it does not exist");
-    }
+    ROS_WARN_STREAM_COND(!found_layers.count(layer), "Cannot clear layer " << layer << " because it does not exist");
   }
 }
 

--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -38,6 +38,7 @@
 #include <pluginlib/class_list_macros.h>
 #include <boost/pointer_cast.hpp>
 #include <vector>
+#include <unordered_set>
 
 //register this planner as a RecoveryBehavior plugin
 PLUGINLIB_EXPORT_CLASS(clear_costmap_recovery::ClearCostmapRecovery, nav_core::RecoveryBehavior)
@@ -141,6 +142,8 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
   double x = pose.pose.position.x;
   double y = pose.pose.position.y;
 
+  std::unordered_set<std::string> cleared_layers;
+
   for (std::vector<boost::shared_ptr<costmap_2d::Layer> >::iterator pluginp = plugins->begin(); pluginp != plugins->end(); ++pluginp) {
     boost::shared_ptr<costmap_2d::Layer> plugin = *pluginp;
     std::string name = plugin->getName();
@@ -151,6 +154,8 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
 
     if(clearable_layers_.count(name)!=0){
 
+      cleared_layers.insert(name);
+
       // check if the value is convertable
       if(!dynamic_cast<costmap_2d::CostmapLayer*>(plugin.get())){
         ROS_ERROR_STREAM("Layer " << name << " is not derived from costmap_2d::CostmapLayer");
@@ -160,6 +165,12 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
       boost::shared_ptr<costmap_2d::CostmapLayer> costmap;
       costmap = boost::static_pointer_cast<costmap_2d::CostmapLayer>(plugin);
       clearMap(costmap, x, y);
+    }
+  }
+
+  for (const auto& layer : clearable_layers_) {
+    if (!cleared_layers.count(layer)) {
+      ROS_WARN_STREAM("Cannot clear layer " << layer << " because it does not exist");
     }
   }
 }


### PR DESCRIPTION
## Description

Currently the clear costmap recovery doesn't complaint about missing layers, so it's hard to detect a bad configuration.
This PR adds logs so that we can easily spot if there's something wrong with the config.