### PR TITLE
publish potential and delete allocated memory when goal is blocked

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -312,10 +312,11 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
     geometry_msgs::PoseStamped best_pose = goal;
     bool goal_blocked = !found_legal;
     if (!found_legal) {
-      // if calculatePotentials did not result in a valid potential at the goal cell,
-      // check if any cells within tolerance around the goal have are in free space
-      // (if not, report that the goal is blocked) and have a valid potential
-      // (-> path can be found to displaced goal)
+      // calculatePotentials did not result in a valid potential at the goal cell:
+      // Check if any cells within tolerance around the goal have a valid potential:
+      // - if so, set found_legal to true and displace the goal,
+      //   such the getPlanFromPotential will generate a path to the displaced goal
+      // - if not, check whether any of the cells are even in free space (if not, report goal blocked)
       double resolution = costmap_->getResolution();
       geometry_msgs::PoseStamped p = goal;
 

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -341,6 +341,12 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
       if (goal_blocked) {
         message = "All cells around the goal within the tolerance are in collision";
         ROS_ERROR_STREAM(message);
+        if(publish_potential_)
+          publishPotential(potential_array_);
+        if(show_footprint_radii_)
+          showFootprintRadii();
+
+        delete[] potential_array_;
         return mbf_msgs::GetPathResult::BLOCKED_GOAL;
       }
 

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -310,14 +310,18 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
 
 
     geometry_msgs::PoseStamped best_pose = goal;
+    bool goal_blocked = !found_legal;
     if (!found_legal) {
+      // if calculatePotentials did not result in a valid potential at the goal cell,
+      // check if any cells within tolerance around the goal have are in free space
+      // (if not, report that the goal is blocked) and have a valid potential
+      // (-> path can be found to displaced goal)
       double resolution = costmap_->getResolution();
       geometry_msgs::PoseStamped p = goal;
 
       double best_sdist = DBL_MAX;
 
       unsigned int mx, my;
-      bool goal_blocked = true;
       for(double dy = -tolerance; dy <= tolerance; dy += resolution){
         p.pose.position.y = goal.pose.position.y + dy;
         const double dx = std::sqrt(tolerance*tolerance - dy*dy);
@@ -338,18 +342,6 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
         }
       }
 
-      if (goal_blocked) {
-        message = "All cells around the goal within the tolerance are in collision";
-        ROS_ERROR_STREAM(message);
-        if(publish_potential_)
-          publishPotential(potential_array_);
-        if(show_footprint_radii_)
-          showFootprintRadii();
-
-        delete[] potential_array_;
-        return mbf_msgs::GetPathResult::BLOCKED_GOAL;
-      }
-
       if (found_legal) {
         if(old_navfn_behavior_){
           goal_x = goal_x_i;
@@ -366,6 +358,13 @@ uint32_t GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const 
         publishPotential(potential_array_);
     if(show_footprint_radii_)
       showFootprintRadii();
+
+    if (goal_blocked) {
+      message = "All cells around the goal within the tolerance are in collision";
+      ROS_ERROR_STREAM(message);
+      delete[] potential_array_;
+      return mbf_msgs::GetPathResult::BLOCKED_GOAL;
+    }
 
     if (found_legal) {
         //extract the plan


### PR DESCRIPTION
this [commit](https://github.com/rapyuta-robotics/ros-navigation/commit/f0301487a993d68f969a3d6297ee87d5a3baf643) introduced a return statement after this line

https://github.com/rapyuta-robotics/ros-navigation/blob/f0301487a993d68f969a3d6297ee87d5a3baf643/global_planner/src/planner_core.cpp#L303

which resulted in the function returning without reaching the cleanup at the end of the function

https://github.com/rapyuta-robotics/ros-navigation/blob/02d5efb61536a70c6e58df973468c4c7dd8deb0f/global_planner/src/planner_core.cpp#L384-L385

So this PR de-allocates the memory before returning, and returns later such that the potential and footprint visualization are published. I also added some comments to make it easier to understand the logic.