### PR TITLE
[PoC] Timed Costmap 

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_util.h
+++ b/base_local_planner/include/base_local_planner/local_planner_util.h
@@ -61,7 +61,6 @@ private:
   std::string name_;
   std::string global_frame_;
 
-  costmap_2d::Costmap2D* costmap_;
   costmap_2d::LayeredCostmap* layered_costmap_;
 
   tf2_ros::Buffer* tf_;
@@ -88,8 +87,7 @@ public:
   ~LocalPlannerUtil() {
   }
 
-  void initialize(tf2_ros::Buffer* tf,
-      costmap_2d::Costmap2D* costmap, costmap_2d::LayeredCostmap* layered_costmap,
+  void initialize(tf2_ros::Buffer* tf, costmap_2d::LayeredCostmap* layered_costmap,
       std::string global_frame);
 
   bool getGoal(geometry_msgs::PoseStamped& goal_pose);
@@ -100,7 +98,7 @@ public:
 
   bool getLocalPlan(const geometry_msgs::PoseStamped& global_pose, std::vector<geometry_msgs::PoseStamped>& transformed_plan);
 
-  costmap_2d::Costmap2D* getCostmap();
+  costmap_2d::Costmap2D* getCostmap(double t = 0);
 
   costmap_2d::LayeredCostmap* getLayeredCostmap();
 

--- a/base_local_planner/include/base_local_planner/local_planner_util.h
+++ b/base_local_planner/include/base_local_planner/local_planner_util.h
@@ -62,8 +62,6 @@ private:
   std::string global_frame_;
 
   costmap_2d::Costmap2D* costmap_;
-  std::vector<costmap_2d::Costmap2D>* timed_costmaps_;
-
   costmap_2d::LayeredCostmap* layered_costmap_;
 
   tf2_ros::Buffer* tf_;
@@ -91,7 +89,7 @@ public:
   }
 
   void initialize(tf2_ros::Buffer* tf,
-      costmap_2d::Costmap2D* costmap, std::vector<costmap_2d::Costmap2D>* timed_costmaps,
+      costmap_2d::Costmap2D* costmap, costmap_2d::LayeredCostmap* layered_costmap,
       std::string global_frame);
 
   bool getGoal(geometry_msgs::PoseStamped& goal_pose);
@@ -103,9 +101,8 @@ public:
   bool getLocalPlan(const geometry_msgs::PoseStamped& global_pose, std::vector<geometry_msgs::PoseStamped>& transformed_plan);
 
   costmap_2d::Costmap2D* getCostmap();
-  
-  std::vector<costmap_2d::Costmap2D>* getTimedCostmaps();
 
+  costmap_2d::LayeredCostmap* getLayeredCostmap();
 
   LocalPlannerLimits getCurrentLimits();
 

--- a/base_local_planner/include/base_local_planner/local_planner_util.h
+++ b/base_local_planner/include/base_local_planner/local_planner_util.h
@@ -62,6 +62,10 @@ private:
   std::string global_frame_;
 
   costmap_2d::Costmap2D* costmap_;
+  std::vector<costmap_2d::Costmap2D>* timed_costmaps_;
+
+  costmap_2d::LayeredCostmap* layered_costmap_;
+
   tf2_ros::Buffer* tf_;
 
 
@@ -87,7 +91,7 @@ public:
   }
 
   void initialize(tf2_ros::Buffer* tf,
-      costmap_2d::Costmap2D* costmap,
+      costmap_2d::Costmap2D* costmap, std::vector<costmap_2d::Costmap2D>* timed_costmaps,
       std::string global_frame);
 
   bool getGoal(geometry_msgs::PoseStamped& goal_pose);
@@ -99,6 +103,9 @@ public:
   bool getLocalPlan(const geometry_msgs::PoseStamped& global_pose, std::vector<geometry_msgs::PoseStamped>& transformed_plan);
 
   costmap_2d::Costmap2D* getCostmap();
+  
+  std::vector<costmap_2d::Costmap2D>* getTimedCostmaps();
+
 
   LocalPlannerLimits getCurrentLimits();
 

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -42,6 +42,8 @@
 
 #include <base_local_planner/costmap_model.h>
 #include <costmap_2d/costmap_2d.h>
+#include <costmap_2d/layered_costmap.h>
+
 
 namespace base_local_planner {
 
@@ -53,7 +55,7 @@ namespace base_local_planner {
 class ObstacleCostFunction : public TrajectoryCostFunction {
 
 public:
-  ObstacleCostFunction(std::vector<costmap_2d::Costmap2D>* timed_costmaps);
+  ObstacleCostFunction(costmap_2d::LayeredCostmap* layered_costmap);
   ~ObstacleCostFunction();
 
   ExePathOutcome prepare(const geometry_msgs::PoseStamped& current_pose);
@@ -73,20 +75,12 @@ public:
       const double& y,
       const double& th,
       const std::vector<geometry_msgs::Point>& scaled_footprint,
-      costmap_2d::Costmap2D* costmap,
-      base_local_planner::WorldModel* world_model);
-
-  double footprintCost(
-      const double& x,
-      const double& y,
-      const double& th,
-      const std::vector<geometry_msgs::Point>& scaled_footprint,
-      std::vector<costmap_2d::Costmap2D>* timed_costmaps,
+      costmap_2d::LayeredCostmap* layered_costmap,
       base_local_planner::WorldModel* world_model,
-      double t);
+      double t = 0.0);
 
 private:
-  std::vector<costmap_2d::Costmap2D>* timed_costmaps_;
+  costmap_2d::LayeredCostmap* layered_costmap_;
   costmap_2d::Costmap2D* costmap_;
   std::vector<geometry_msgs::Point> footprint_spec_;
   base_local_planner::WorldModel* world_model_;

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -56,7 +56,6 @@ class ObstacleCostFunction : public TrajectoryCostFunction {
 
 public:
   ObstacleCostFunction(costmap_2d::LayeredCostmap* layered_costmap);
-  ~ObstacleCostFunction();
 
   ExePathOutcome prepare(const geometry_msgs::PoseStamped& current_pose);
   double scoreTrajectory(Trajectory &traj);
@@ -76,14 +75,11 @@ public:
       const double& th,
       const std::vector<geometry_msgs::Point>& scaled_footprint,
       costmap_2d::LayeredCostmap* layered_costmap,
-      base_local_planner::WorldModel* world_model,
       double t = 0.0);
 
 private:
   costmap_2d::LayeredCostmap* layered_costmap_;
-  costmap_2d::Costmap2D* costmap_;
   std::vector<geometry_msgs::Point> footprint_spec_;
-  base_local_planner::WorldModel* world_model_;
   double max_trans_vel_;
   bool sum_scores_;
   //footprint scaling with velocity;

--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -53,7 +53,7 @@ namespace base_local_planner {
 class ObstacleCostFunction : public TrajectoryCostFunction {
 
 public:
-  ObstacleCostFunction(costmap_2d::Costmap2D* costmap);
+  ObstacleCostFunction(std::vector<costmap_2d::Costmap2D>* timed_costmaps);
   ~ObstacleCostFunction();
 
   ExePathOutcome prepare(const geometry_msgs::PoseStamped& current_pose);
@@ -67,6 +67,7 @@ public:
 
   // helper functions, made static for easy unit testing
   static double getScalingFactor(const Trajectory &traj, double scaling_speed, double max_trans_vel);
+  
   double footprintCost(
       const double& x,
       const double& y,
@@ -75,7 +76,17 @@ public:
       costmap_2d::Costmap2D* costmap,
       base_local_planner::WorldModel* world_model);
 
+  double footprintCost(
+      const double& x,
+      const double& y,
+      const double& th,
+      const std::vector<geometry_msgs::Point>& scaled_footprint,
+      std::vector<costmap_2d::Costmap2D>* timed_costmaps,
+      base_local_planner::WorldModel* world_model,
+      double t);
+
 private:
+  std::vector<costmap_2d::Costmap2D>* timed_costmaps_;
   costmap_2d::Costmap2D* costmap_;
   std::vector<geometry_msgs::Point> footprint_spec_;
   base_local_planner::WorldModel* world_model_;

--- a/base_local_planner/src/local_planner_util.cpp
+++ b/base_local_planner/src/local_planner_util.cpp
@@ -44,13 +44,13 @@ namespace base_local_planner {
 void LocalPlannerUtil::initialize(
     tf2_ros::Buffer* tf,
     costmap_2d::Costmap2D* costmap,
-    std::vector<costmap_2d::Costmap2D>* timed_costmaps,
+    costmap_2d::LayeredCostmap* layered_costmap,
     std::string global_frame) {
 
   if(!initialized_) {
     tf_ = tf;
     costmap_ = costmap;
-    timed_costmaps_ = timed_costmaps;    
+    layered_costmap_ = layered_costmap;    
     global_frame_ = global_frame;
     initialized_ = true;
   }
@@ -77,9 +77,8 @@ costmap_2d::Costmap2D* LocalPlannerUtil::getCostmap() {
   return costmap_;
 }
 
-std::vector<costmap_2d::Costmap2D>* LocalPlannerUtil::getTimedCostmaps() {
-  std::vector<costmap_2d::Costmap2D> a = *timed_costmaps_;
-  return timed_costmaps_;
+costmap_2d::LayeredCostmap* LocalPlannerUtil::getLayeredCostmap() {
+  return layered_costmap_;
 }
 
 LocalPlannerLimits LocalPlannerUtil::getCurrentLimits() {

--- a/base_local_planner/src/local_planner_util.cpp
+++ b/base_local_planner/src/local_planner_util.cpp
@@ -43,13 +43,11 @@ namespace base_local_planner {
 
 void LocalPlannerUtil::initialize(
     tf2_ros::Buffer* tf,
-    costmap_2d::Costmap2D* costmap,
     costmap_2d::LayeredCostmap* layered_costmap,
     std::string global_frame) {
 
   if(!initialized_) {
     tf_ = tf;
-    costmap_ = costmap;
     layered_costmap_ = layered_costmap;    
     global_frame_ = global_frame;
     initialized_ = true;
@@ -73,8 +71,8 @@ void LocalPlannerUtil::reconfigureCB(LocalPlannerLimits &config, bool restore_de
   limits_ = LocalPlannerLimits(config);
 }
 
-costmap_2d::Costmap2D* LocalPlannerUtil::getCostmap() {
-  return costmap_;
+costmap_2d::Costmap2D* LocalPlannerUtil::getCostmap(double t) {
+  return layered_costmap_->getCostmap(t);
 }
 
 costmap_2d::LayeredCostmap* LocalPlannerUtil::getLayeredCostmap() {
@@ -115,7 +113,7 @@ bool LocalPlannerUtil::getLocalPlan(const geometry_msgs::PoseStamped& global_pos
       *tf_,
       global_plan_,
       global_pose,
-      *costmap_,
+      *layered_costmap_->getCostmap(),
       global_frame_,
       transformed_plan)) {
     ROS_WARN("Could not transform the global plan to the frame of the controller");

--- a/base_local_planner/src/local_planner_util.cpp
+++ b/base_local_planner/src/local_planner_util.cpp
@@ -44,10 +44,13 @@ namespace base_local_planner {
 void LocalPlannerUtil::initialize(
     tf2_ros::Buffer* tf,
     costmap_2d::Costmap2D* costmap,
+    std::vector<costmap_2d::Costmap2D>* timed_costmaps,
     std::string global_frame) {
+
   if(!initialized_) {
     tf_ = tf;
     costmap_ = costmap;
+    timed_costmaps_ = timed_costmaps;    
     global_frame_ = global_frame;
     initialized_ = true;
   }
@@ -72,6 +75,11 @@ void LocalPlannerUtil::reconfigureCB(LocalPlannerLimits &config, bool restore_de
 
 costmap_2d::Costmap2D* LocalPlannerUtil::getCostmap() {
   return costmap_;
+}
+
+std::vector<costmap_2d::Costmap2D>* LocalPlannerUtil::getTimedCostmaps() {
+  std::vector<costmap_2d::Costmap2D> a = *timed_costmaps_;
+  return timed_costmaps_;
 }
 
 LocalPlannerLimits LocalPlannerUtil::getCurrentLimits() {

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -44,8 +44,8 @@
 
 namespace base_local_planner {
 
-ObstacleCostFunction::ObstacleCostFunction(std::vector<costmap_2d::Costmap2D>* timed_costmaps)
-    : timed_costmaps_(timed_costmaps), costmap_(), sum_scores_(false), sideward_inflation_scale_(1.0) {
+ObstacleCostFunction::ObstacleCostFunction(costmap_2d::LayeredCostmap* layered_costmap)
+    : layered_costmap_(layered_costmap), costmap_(layered_costmap->getCostmap()), sum_scores_(false), sideward_inflation_scale_(1.0) {
   // if (costmap_ != NULL) {
   //   world_model_ = new base_local_planner::CostmapModel(*costmap_);
   //   // Check what this is being used for!!!!!!
@@ -121,7 +121,7 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
         scaled_footprint,
-        timed_costmaps_, world_model_, i * traj.time_delta_); 
+        layered_costmap_, world_model_, i * traj.time_delta_); 
 
     if(f_cost < 0){
         return f_cost;
@@ -150,13 +150,18 @@ double ObstacleCostFunction::footprintCost (
     const double& y,
     const double& th,
     const std::vector<geometry_msgs::Point>& scaled_footprint,
-    costmap_2d::Costmap2D* costmap,
-    base_local_planner::WorldModel* world_model) {
+    costmap_2d::LayeredCostmap* layered_costmap,
+    base_local_planner::WorldModel* world_model,
+    double t) {
 
   //check if the footprint is legal
   // TODO: Cache inscribed radius
+  std::vector<costmap_2d::Costmap2D> timed_costmaps = layered_costmap->getTimedCostmaps();
+  costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap();
+  double timestep = layered_costmap->getTimestep();
+  int n = round(std::min((int)(t/timestep), (int)timed_costmaps.size()-1));
 
-  base_local_planner::CostmapModel world_model_ = *costmap; // create new world model??
+  base_local_planner::CostmapModel world_model_ = timed_costmaps[n]; // create new world model??
 
   double footprint_cost = world_model_.footprintCost(x, y, th, scaled_footprint);
 
@@ -178,26 +183,5 @@ double ObstacleCostFunction::footprintCost (
 
   return occ_cost;
 }
-
-double ObstacleCostFunction::footprintCost (
-    const double& x,
-    const double& y,
-    const double& th,
-    const std::vector<geometry_msgs::Point>& scaled_footprint,
-    std::vector<costmap_2d::Costmap2D>* timed_costmaps,
-    base_local_planner::WorldModel* world_model,
-    double t) 
-    {
-      double timestep = 0.3;   // MAKE PARAMETER OR PASS FROM LAYERED COSTMAP (hard coded for testing)
-      int n = std::min((int)(t/timestep), (int)timed_costmaps->size()-1);
-      double cost = footprintCost(x, y, th, scaled_footprint, (&(*timed_costmaps)[n]), world_model);
-
-      if (cost > 240 && t > 0.4)
-      {
-        ROS_INFO_STREAM("<- put breakpoint here for debugging");
-      }
-      return cost;
-    }
-
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -158,8 +158,8 @@ double ObstacleCostFunction::footprintCost (
   // TODO: Cache inscribed radius
   costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap(t);
 
-  if (costmap_ != NULL) {
-    world_model_ = new base_local_planner::CostmapModel(*costmap_);
+  if (costmap != NULL) {
+    world_model_ = new base_local_planner::CostmapModel(*costmap);
   }
 
   double footprint_cost = world_model_->footprintCost(x, y, th, scaled_footprint);

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -44,11 +44,12 @@
 
 namespace base_local_planner {
 
-ObstacleCostFunction::ObstacleCostFunction(costmap_2d::Costmap2D* costmap)
-    : costmap_(costmap), sum_scores_(false), sideward_inflation_scale_(1.0) {
-  if (costmap != NULL) {
-    world_model_ = new base_local_planner::CostmapModel(*costmap_);
-  }
+ObstacleCostFunction::ObstacleCostFunction(std::vector<costmap_2d::Costmap2D>* timed_costmaps)
+    : timed_costmaps_(timed_costmaps), costmap_(), sum_scores_(false), sideward_inflation_scale_(1.0) {
+  // if (costmap_ != NULL) {
+  //   world_model_ = new base_local_planner::CostmapModel(*costmap_);
+  //   // Check what this is being used for!!!!!!
+  // }
 
   ros::NodeHandle pnh("~");
   sideward_inflation_scale_sub_ = pnh.subscribe<std_msgs::Float32>("sideward_inflation_scale", 1, [&](const std_msgs::Float32ConstPtr& msg){
@@ -103,6 +104,7 @@ ExePathOutcome ObstacleCostFunction::prepare(const geometry_msgs::PoseStamped& c
 
 double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
   double cost = 0;
+
   double px, py, pth;
   if (footprint_spec_.size() == 0) {
     // Bug, should never happen
@@ -119,7 +121,7 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
         scaled_footprint,
-        costmap_, world_model_);
+        timed_costmaps_, world_model_, i * traj.time_delta_); 
 
     if(f_cost < 0){
         return f_cost;
@@ -153,7 +155,10 @@ double ObstacleCostFunction::footprintCost (
 
   //check if the footprint is legal
   // TODO: Cache inscribed radius
-  double footprint_cost = world_model->footprintCost(x, y, th, scaled_footprint);
+
+  base_local_planner::CostmapModel world_model_ = *costmap; // create new world model??
+
+  double footprint_cost = world_model_.footprintCost(x, y, th, scaled_footprint);
 
   if (footprint_cost < 0) {
     return -6.0;
@@ -173,5 +178,26 @@ double ObstacleCostFunction::footprintCost (
 
   return occ_cost;
 }
+
+double ObstacleCostFunction::footprintCost (
+    const double& x,
+    const double& y,
+    const double& th,
+    const std::vector<geometry_msgs::Point>& scaled_footprint,
+    std::vector<costmap_2d::Costmap2D>* timed_costmaps,
+    base_local_planner::WorldModel* world_model,
+    double t) 
+    {
+      double timestep = 0.3;   // MAKE PARAMETER OR PASS FROM LAYERED COSTMAP (hard coded for testing)
+      int n = std::min((int)(t/timestep), (int)timed_costmaps->size()-1);
+      double cost = footprintCost(x, y, th, scaled_footprint, (&(*timed_costmaps)[n]), world_model);
+
+      if (cost > 240 && t > 0.4)
+      {
+        ROS_INFO_STREAM("<- put breakpoint here for debugging");
+      }
+      return cost;
+    }
+
 
 } /* namespace base_local_planner */

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -148,10 +148,10 @@ double ObstacleCostFunction::footprintCost (
   costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap(t);
 
   if (costmap == NULL) {
-    return -1.0; // What to return ???????????
+    return -10.0; // What to return ???????????
   }
-
-  std::unique_ptr<base_local_planner::WorldModel> world_model(new base_local_planner::CostmapModel(*costmap));
+  
+  std::unique_ptr<base_local_planner::WorldModel> world_model = std::make_unique<base_local_planner::CostmapModel>(*costmap);
 
   double footprint_cost = world_model->footprintCost(x, y, th, scaled_footprint);
   

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -156,14 +156,13 @@ double ObstacleCostFunction::footprintCost (
 
   //check if the footprint is legal
   // TODO: Cache inscribed radius
-  std::vector<costmap_2d::Costmap2D> timed_costmaps = layered_costmap->getTimedCostmaps();
-  costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap();
-  double timestep = layered_costmap->getTimestep();
-  int n = round(std::min((int)(t/timestep), (int)timed_costmaps.size()-1));
+  costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap(t);
 
-  base_local_planner::CostmapModel world_model_ = timed_costmaps[n]; // create new world model??
+  if (costmap_ != NULL) {
+    world_model_ = new base_local_planner::CostmapModel(*costmap_);
+  }
 
-  double footprint_cost = world_model_.footprintCost(x, y, th, scaled_footprint);
+  double footprint_cost = world_model_->footprintCost(x, y, th, scaled_footprint);
 
   if (footprint_cost < 0) {
     return -6.0;

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -45,22 +45,12 @@
 namespace base_local_planner {
 
 ObstacleCostFunction::ObstacleCostFunction(costmap_2d::LayeredCostmap* layered_costmap)
-    : layered_costmap_(layered_costmap), costmap_(layered_costmap->getCostmap()), sum_scores_(false), sideward_inflation_scale_(1.0) {
-  // if (costmap_ != NULL) {
-  //   world_model_ = new base_local_planner::CostmapModel(*costmap_);
-  //   // Check what this is being used for!!!!!!
-  // }
+    : layered_costmap_(layered_costmap), sum_scores_(false), sideward_inflation_scale_(1.0) {
 
   ros::NodeHandle pnh("~");
   sideward_inflation_scale_sub_ = pnh.subscribe<std_msgs::Float32>("sideward_inflation_scale", 1, [&](const std_msgs::Float32ConstPtr& msg){
     sideward_inflation_scale_ = msg->data;
   });
-}
-
-ObstacleCostFunction::~ObstacleCostFunction() {
-  if (world_model_ != NULL) {
-    delete world_model_;
-  }
 }
 
 
@@ -121,7 +111,7 @@ double ObstacleCostFunction::scoreTrajectory(Trajectory &traj) {
     traj.getPoint(i, px, py, pth);
     double f_cost = footprintCost(px, py, pth,
         scaled_footprint,
-        layered_costmap_, world_model_, i * traj.time_delta_); 
+        layered_costmap_, i * traj.time_delta_); 
 
     if(f_cost < 0){
         return f_cost;
@@ -151,19 +141,20 @@ double ObstacleCostFunction::footprintCost (
     const double& th,
     const std::vector<geometry_msgs::Point>& scaled_footprint,
     costmap_2d::LayeredCostmap* layered_costmap,
-    base_local_planner::WorldModel* world_model,
     double t) {
 
   //check if the footprint is legal
   // TODO: Cache inscribed radius
   costmap_2d::Costmap2D* costmap = layered_costmap->getCostmap(t);
 
-  if (costmap != NULL) {
-    world_model_ = new base_local_planner::CostmapModel(*costmap);
+  if (costmap == NULL) {
+    return -1.0; // What to return ???????????
   }
 
-  double footprint_cost = world_model_->footprintCost(x, y, th, scaled_footprint);
+  std::unique_ptr<base_local_planner::WorldModel> world_model(new base_local_planner::CostmapModel(*costmap));
 
+  double footprint_cost = world_model->footprintCost(x, y, th, scaled_footprint);
+  
   if (footprint_cost < 0) {
     return -6.0;
   }

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -152,6 +152,11 @@ public:
       return layered_costmap_->getCostmap();
     }
 
+  std::vector<Costmap2D>* getTimedCostmaps() const
+    {
+      return layered_costmap_->getTimedCostmaps();
+    }
+
   /**
    * @brief  Returns the global frame of the costmap
    * @return The global frame of the costmap

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -152,11 +152,6 @@ public:
       return layered_costmap_->getCostmap();
     }
 
-  std::vector<Costmap2D>* getTimedCostmaps() const
-    {
-      return layered_costmap_->getTimedCostmaps();
-    }
-
   /**
    * @brief  Returns the global frame of the costmap
    * @return The global frame of the costmap

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -64,11 +64,19 @@ public:
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                             double* max_x, double* max_y) {}
 
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y, double t) {
+                              updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);}
+
   /**
    * @brief Actually update the underlying costmap, only within the bounds
    *        calculated during UpdateBounds().
    */
   virtual void updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) {}
+
+  virtual void updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j, double t) {
+                            updateCosts(master_grid, min_i, min_j, max_i, max_j);}
+
 
   /** @brief Stop publishers. */
   virtual void deactivate() {}

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -89,9 +89,9 @@ public:
 
   bool isCurrent();
 
-  Costmap2D* getCostmap(double t = 0.0);
+  costmap_2d::Costmap2D* getCostmap(double t = 0.0);
 
-  const double getTimestep();
+  double getTimestep() const;
 
   bool isRolling()
   {

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -91,7 +91,7 @@ public:
 
   Costmap2D* getCostmap(double t = 0.0);
 
-  double getTimestep();
+  const double getTimestep();
 
   bool isRolling()
   {
@@ -153,11 +153,6 @@ public:
    * This is updated by setFootprint(). */
   double getInscribedRadius() { return inscribed_radius_; }
 
-
-  // unsigned char getCost(unsigned int mx, unsigned int my, double t) const;
-
-
-
 private:
   std::vector<Costmap2D> timed_costmaps_;
   std::string global_frame_;
@@ -166,8 +161,10 @@ private:
 
   bool current_;
   double minx_, miny_, maxx_, maxy_;
-  double timestep_, prediction_time_;
   unsigned int bx0_, bxn_, by0_, byn_;
+
+  // To-Do: Make parameters (ideally should be same as planner sim_time and sim_granularity?)
+  double timestep_, prediction_time_; 
 
   std::vector<boost::shared_ptr<Layer> > plugins_;
 

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -89,15 +89,9 @@ public:
 
   bool isCurrent();
 
-  Costmap2D* getCostmap()
-  {
-    return &costmap_;
-  }
-
-  std::vector<Costmap2D> getTimedCostmaps();
+  Costmap2D* getCostmap(double t = 0.0);
 
   double getTimestep();
-
 
   bool isRolling()
   {
@@ -106,7 +100,7 @@ public:
 
   bool isTrackingUnknown()
   {
-    return costmap_.getDefaultValue() == costmap_2d::NO_INFORMATION;
+    return getCostmap()->getDefaultValue() == costmap_2d::NO_INFORMATION;
   }
 
   std::vector<boost::shared_ptr<Layer> >* getPlugins()
@@ -166,7 +160,6 @@ public:
 
 private:
   std::vector<Costmap2D> timed_costmaps_;
-  Costmap2D costmap_;
   std::string global_frame_;
 
   bool rolling_window_;  /// < @brief Whether or not the costmap should roll with the robot

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -94,6 +94,8 @@ public:
     return &costmap_;
   }
 
+  std::vector<Costmap2D>* getTimedCostmaps();
+
   bool isRolling()
   {
     return rolling_window_;
@@ -154,7 +156,13 @@ public:
    * This is updated by setFootprint(). */
   double getInscribedRadius() { return inscribed_radius_; }
 
+
+  // unsigned char getCost(unsigned int mx, unsigned int my, double t) const;
+
+
+
 private:
+  std::vector<Costmap2D> timed_costmaps_;
   Costmap2D costmap_;
   std::string global_frame_;
 
@@ -162,6 +170,7 @@ private:
 
   bool current_;
   double minx_, miny_, maxx_, maxy_;
+  double timestep_, prediction_time_;
   unsigned int bx0_, bxn_, by0_, byn_;
 
   std::vector<boost::shared_ptr<Layer> > plugins_;

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -94,7 +94,10 @@ public:
     return &costmap_;
   }
 
-  std::vector<Costmap2D>* getTimedCostmaps();
+  std::vector<Costmap2D> getTimedCostmaps();
+
+  double getTimestep();
+
 
   bool isRolling()
   {

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -49,6 +49,8 @@ namespace costmap_2d
 
 LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown) :
     costmap_(),
+    timestep_(0.3),
+    prediction_time_(1.2),
     global_frame_(global_frame),
     rolling_window_(rolling_window),
     current_(false),
@@ -64,6 +66,7 @@ LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bo
     size_locked_(false),
     circumscribed_radius_(1.0),
     inscribed_radius_(0.1)
+
 {
   if (track_unknown)
     costmap_.setDefaultValue(NO_INFORMATION);
@@ -96,9 +99,9 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
   // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
   // implement thread unsafe updateBounds() functions.
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
+  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));  // Change to create new costmap_ object instead??
 
-  // if we're using a rolling buffer costmap... we need to update the origin using the robot's position
+  // if we're using a rolling buffer costmap_... we need to update the origin using the robot's position
   if (rolling_window_)
   {
     double new_origin_x = robot_x - costmap_.getSizeInMetersX() / 2;
@@ -112,54 +115,63 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   minx_ = miny_ = 1e30;
   maxx_ = maxy_ = -1e30;
 
-  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
-       ++plugin)
+  timed_costmaps_.clear();
+
+  // Create new costmap_ in this loop and add to costmap_ array?
+  for (double t = 0; t <= prediction_time_; t += timestep_)
   {
-    if(!(*plugin)->isEnabled())
-      continue;
-    double prev_minx = minx_;
-    double prev_miny = miny_;
-    double prev_maxx = maxx_;
-    double prev_maxy = maxy_;
-    (*plugin)->updateBounds(robot_x, robot_y, robot_yaw, &minx_, &miny_, &maxx_, &maxy_);
-    if (minx_ > prev_minx || miny_ > prev_miny || maxx_ < prev_maxx || maxy_ < prev_maxy)
+    // Costmap2D costmap_ = costmap_;
+    for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
+        ++plugin)
     {
-      ROS_WARN_THROTTLE(1.0, "Illegal bounds change, was [tl: (%f, %f), br: (%f, %f)], but "
-                        "is now [tl: (%f, %f), br: (%f, %f)]. The offending layer is %s",
-                        prev_minx, prev_miny, prev_maxx , prev_maxy,
-                        minx_, miny_, maxx_ , maxy_,
-                        (*plugin)->getName().c_str());
+      if(!(*plugin)->isEnabled())
+        continue;
+      double prev_minx = minx_;
+      double prev_miny = miny_;
+      double prev_maxx = maxx_;
+      double prev_maxy = maxy_;
+      (*plugin)->updateBounds(robot_x, robot_y, robot_yaw, &minx_, &miny_, &maxx_, &maxy_, t);  // Add time here ????
+      if (minx_ > prev_minx || miny_ > prev_miny || maxx_ < prev_maxx || maxy_ < prev_maxy)
+      {
+        ROS_WARN_THROTTLE(1.0, "Illegal bounds change, was [tl: (%f, %f), br: (%f, %f)], but "
+                          "is now [tl: (%f, %f), br: (%f, %f)]. The offending layer is %s",
+                          prev_minx, prev_miny, prev_maxx , prev_maxy,
+                          minx_, miny_, maxx_ , maxy_,
+                          (*plugin)->getName().c_str());
+      }
     }
+
+    int x0, xn, y0, yn;
+    costmap_.worldToMapEnforceBounds(minx_, miny_, x0, y0);   
+    costmap_.worldToMapEnforceBounds(maxx_, maxy_, xn, yn);
+
+    x0 = std::max(0, x0);
+    xn = std::min(int(costmap_.getSizeInCellsX()), xn + 1);
+    y0 = std::max(0, y0);
+    yn = std::min(int(costmap_.getSizeInCellsY()), yn + 1);
+
+    ROS_DEBUG("Updating area x: [%d, %d] y: [%d, %d]", x0, xn, y0, yn);
+
+    if (xn < x0 || yn < y0)
+      return;
+
+    costmap_.resetMap(x0, y0, xn, yn);
+    for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
+        ++plugin)
+    {
+      if((*plugin)->isEnabled())
+        (*plugin)->updateCosts(costmap_, x0, y0, xn, yn, t); // Add time here
+    }
+
+    bx0_ = x0;
+    bxn_ = xn;
+    by0_ = y0;
+    byn_ = yn;
+
+    initialized_ = true;
+    timed_costmaps_.emplace_back(costmap_);
   }
-
-  int x0, xn, y0, yn;
-  costmap_.worldToMapEnforceBounds(minx_, miny_, x0, y0);
-  costmap_.worldToMapEnforceBounds(maxx_, maxy_, xn, yn);
-
-  x0 = std::max(0, x0);
-  xn = std::min(int(costmap_.getSizeInCellsX()), xn + 1);
-  y0 = std::max(0, y0);
-  yn = std::min(int(costmap_.getSizeInCellsY()), yn + 1);
-
-  ROS_DEBUG("Updating area x: [%d, %d] y: [%d, %d]", x0, xn, y0, yn);
-
-  if (xn < x0 || yn < y0)
-    return;
-
-  costmap_.resetMap(x0, y0, xn, yn);
-  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
-       ++plugin)
-  {
-    if((*plugin)->isEnabled())
-      (*plugin)->updateCosts(costmap_, x0, y0, xn, yn);
-  }
-
-  bx0_ = x0;
-  bxn_ = xn;
-  by0_ = y0;
-  byn_ = yn;
-
-  initialized_ = true;
+  costmap_ = timed_costmaps_.front();
 }
 
 bool LayeredCostmap::isCurrent()
@@ -173,6 +185,13 @@ bool LayeredCostmap::isCurrent()
   }
   return current_;
 }
+
+
+std::vector<Costmap2D>* LayeredCostmap::getTimedCostmaps()
+  {
+    return &timed_costmaps_;
+  }
+
 
 void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::Point>& footprint_spec)
 {

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -87,30 +87,41 @@ LayeredCostmap::~LayeredCostmap()
 
 void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                                double origin_y, bool size_locked)
-{
+{  
+  std::vector<boost::unique_lock<Costmap2D::mutex_t>> locks;
+  for (costmap_2d::Costmap2D& costmap : timed_costmaps_) {
+    locks.emplace_back(*(costmap.getMutex()));
+  }
+
   for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
-    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex()));
     size_locked_ = size_locked;
     costmap.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
-    for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
+  }
+  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
         ++plugin)
-    {
-      (*plugin)->matchSize();
-    }
+  {
+    (*plugin)->matchSize();
   }
 }
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
+  // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
+  // implement thread unsafe updateBounds() functions.
+  // Change to create new vector instead and copy after loop?
+  std::vector<boost::unique_lock<Costmap2D::mutex_t>> locks;
+  for (costmap_2d::Costmap2D& costmap : timed_costmaps_) {
+    locks.emplace_back(*(costmap.getMutex()));
+  }
+
   double t = -timestep_;
+  
+
+  // To-Do: Only compute timed layers inside the loop, non timed layers won't change and thus need to be computed only once
   for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
     t += timestep_;
-    // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
-    // implement thread unsafe updateBounds() functions.
-    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex()));  // Change to create new costmap_ object instead??
-
     // if we're using a rolling buffer costmap_... we need to update the origin using the robot's position
     if (rolling_window_)
     {
@@ -171,9 +182,10 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
     bxn_ = xn;
     by0_ = y0;
     byn_ = yn;
-
-    initialized_ = true;
   }
+  
+  initialized_ = true;
+
 }
 
 bool LayeredCostmap::isCurrent()
@@ -190,11 +202,14 @@ bool LayeredCostmap::isCurrent()
 
 costmap_2d::Costmap2D* LayeredCostmap::getCostmap(double t)
 {
+  if (timed_costmaps_.empty())
+    return NULL;
+
   int n = std::min((int)timed_costmaps_.size()-1, int(t/timestep_));
   return &timed_costmaps_[n];
 }
 
-double LayeredCostmap::getTimestep()
+const double LayeredCostmap::getTimestep()
   {
     return timestep_;
   }

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -209,7 +209,7 @@ costmap_2d::Costmap2D* LayeredCostmap::getCostmap(double t)
   return &timed_costmaps_[n];
 }
 
-const double LayeredCostmap::getTimestep()
+double LayeredCostmap::getTimestep() const
   {
     return timestep_;
   }

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -88,14 +88,10 @@ LayeredCostmap::~LayeredCostmap()
 void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                                double origin_y, bool size_locked)
 {  
-  std::vector<boost::unique_lock<Costmap2D::mutex_t>> locks;
-  for (costmap_2d::Costmap2D& costmap : timed_costmaps_) {
-    locks.emplace_back(*(costmap.getMutex()));
-  }
-
+  size_locked_ = size_locked;
   for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
-    size_locked_ = size_locked;
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex()));
     costmap.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
   }
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
@@ -107,21 +103,16 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
-  // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
-  // implement thread unsafe updateBounds() functions.
-  // Change to create new vector instead and copy after loop?
-  std::vector<boost::unique_lock<Costmap2D::mutex_t>> locks;
-  for (costmap_2d::Costmap2D& costmap : timed_costmaps_) {
-    locks.emplace_back(*(costmap.getMutex()));
-  }
-
   double t = -timestep_;
-  
 
   // To-Do: Only compute timed layers inside the loop, non timed layers won't change and thus need to be computed only once
   for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
     t += timestep_;
+      // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
+    // implement thread unsafe updateBounds() functions.
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex())); 
+
     // if we're using a rolling buffer costmap_... we need to update the origin using the robot's position
     if (rolling_window_)
     {
@@ -203,16 +194,17 @@ bool LayeredCostmap::isCurrent()
 costmap_2d::Costmap2D* LayeredCostmap::getCostmap(double t)
 {
   if (timed_costmaps_.empty())
-    return NULL;
+    return nullptr;
 
   int n = std::min((int)timed_costmaps_.size()-1, int(t/timestep_));
   return &timed_costmaps_[n];
 }
 
+// we're not using this rn...
 double LayeredCostmap::getTimestep() const
-  {
-    return timestep_;
-  }
+{
+  return timestep_;
+}
 
 
 void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::Point>& footprint_spec)

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -48,9 +48,8 @@ namespace costmap_2d
 {
 
 LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown) :
-    costmap_(),
-    timestep_(0.3),
-    prediction_time_(1.2),
+    timestep_(0.1),
+    prediction_time_(1.6),
     global_frame_(global_frame),
     rolling_window_(rolling_window),
     current_(false),
@@ -68,10 +67,14 @@ LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bo
     inscribed_radius_(0.1)
 
 {
-  if (track_unknown)
-    costmap_.setDefaultValue(NO_INFORMATION);
-  else
-    costmap_.setDefaultValue(FREE_SPACE);
+  timed_costmaps_.resize(ceil(prediction_time_/timestep_));
+  for(auto& costmap : timed_costmaps_)
+  {
+    if (track_unknown)
+      costmap.setDefaultValue(NO_INFORMATION);
+    else
+      costmap.setDefaultValue(FREE_SPACE);
+  }
 }
 
 LayeredCostmap::~LayeredCostmap()
@@ -85,42 +88,43 @@ LayeredCostmap::~LayeredCostmap()
 void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                                double origin_y, bool size_locked)
 {
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
-  size_locked_ = size_locked;
-  costmap_.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
-  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
-      ++plugin)
+  for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
-    (*plugin)->matchSize();
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex()));
+    size_locked_ = size_locked;
+    costmap.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
+    for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
+        ++plugin)
+    {
+      (*plugin)->matchSize();
+    }
   }
 }
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
-  // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
-  // implement thread unsafe updateBounds() functions.
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));  // Change to create new costmap_ object instead??
-
-  // if we're using a rolling buffer costmap_... we need to update the origin using the robot's position
-  if (rolling_window_)
+  double t = -timestep_;
+  for(costmap_2d::Costmap2D& costmap : timed_costmaps_)
   {
-    double new_origin_x = robot_x - costmap_.getSizeInMetersX() / 2;
-    double new_origin_y = robot_y - costmap_.getSizeInMetersY() / 2;
-    costmap_.updateOrigin(new_origin_x, new_origin_y);
-  }
+    t += timestep_;
+    // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
+    // implement thread unsafe updateBounds() functions.
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap.getMutex()));  // Change to create new costmap_ object instead??
 
-  if (plugins_.size() == 0)
-    return;
+    // if we're using a rolling buffer costmap_... we need to update the origin using the robot's position
+    if (rolling_window_)
+    {
+      double new_origin_x = robot_x - costmap.getSizeInMetersX() / 2;
+      double new_origin_y = robot_y - costmap.getSizeInMetersY() / 2;
+      costmap.updateOrigin(new_origin_x, new_origin_y);
+    }
 
-  minx_ = miny_ = 1e30;
-  maxx_ = maxy_ = -1e30;
+    if (plugins_.size() == 0)
+      return;
 
-  timed_costmaps_.clear();
+    minx_ = miny_ = 1e30;
+    maxx_ = maxy_ = -1e30;
 
-  // Create new costmap_ in this loop and add to costmap_ array?
-  for (double t = 0; t <= prediction_time_; t += timestep_)
-  {
-    // Costmap2D costmap_ = costmap_;
     for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
         ++plugin)
     {
@@ -130,7 +134,7 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
       double prev_miny = miny_;
       double prev_maxx = maxx_;
       double prev_maxy = maxy_;
-      (*plugin)->updateBounds(robot_x, robot_y, robot_yaw, &minx_, &miny_, &maxx_, &maxy_, t);  // Add time here ????
+      (*plugin)->updateBounds(robot_x, robot_y, robot_yaw, &minx_, &miny_, &maxx_, &maxy_, t);  // Add time here
       if (minx_ > prev_minx || miny_ > prev_miny || maxx_ < prev_maxx || maxy_ < prev_maxy)
       {
         ROS_WARN_THROTTLE(1.0, "Illegal bounds change, was [tl: (%f, %f), br: (%f, %f)], but "
@@ -142,25 +146,25 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
     }
 
     int x0, xn, y0, yn;
-    costmap_.worldToMapEnforceBounds(minx_, miny_, x0, y0);   
-    costmap_.worldToMapEnforceBounds(maxx_, maxy_, xn, yn);
+    costmap.worldToMapEnforceBounds(minx_, miny_, x0, y0);   
+    costmap.worldToMapEnforceBounds(maxx_, maxy_, xn, yn);
 
     x0 = std::max(0, x0);
-    xn = std::min(int(costmap_.getSizeInCellsX()), xn + 1);
+    xn = std::min(int(costmap.getSizeInCellsX()), xn + 1);
     y0 = std::max(0, y0);
-    yn = std::min(int(costmap_.getSizeInCellsY()), yn + 1);
+    yn = std::min(int(costmap.getSizeInCellsY()), yn + 1);
 
     ROS_DEBUG("Updating area x: [%d, %d] y: [%d, %d]", x0, xn, y0, yn);
 
     if (xn < x0 || yn < y0)
       return;
 
-    costmap_.resetMap(x0, y0, xn, yn);
+    costmap.resetMap(x0, y0, xn, yn);
     for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
         ++plugin)
     {
       if((*plugin)->isEnabled())
-        (*plugin)->updateCosts(costmap_, x0, y0, xn, yn, t); // Add time here
+        (*plugin)->updateCosts(costmap, x0, y0, xn, yn, t); // Add time here
     }
 
     bx0_ = x0;
@@ -169,9 +173,7 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
     byn_ = yn;
 
     initialized_ = true;
-    timed_costmaps_.emplace_back(costmap_);
   }
-  costmap_ = timed_costmaps_.front();
 }
 
 bool LayeredCostmap::isCurrent()
@@ -186,11 +188,11 @@ bool LayeredCostmap::isCurrent()
   return current_;
 }
 
-
-std::vector<Costmap2D> LayeredCostmap::getTimedCostmaps()
-  {
-    return timed_costmaps_;
-  }
+costmap_2d::Costmap2D* LayeredCostmap::getCostmap(double t)
+{
+  int n = std::min((int)timed_costmaps_.size()-1, int(t/timestep_));
+  return &timed_costmaps_[n];
+}
 
 double LayeredCostmap::getTimestep()
   {

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -187,9 +187,14 @@ bool LayeredCostmap::isCurrent()
 }
 
 
-std::vector<Costmap2D>* LayeredCostmap::getTimedCostmaps()
+std::vector<Costmap2D> LayeredCostmap::getTimedCostmaps()
   {
-    return &timed_costmaps_;
+    return timed_costmaps_;
+  }
+
+double LayeredCostmap::getTimestep()
+  {
+    return timestep_;
   }
 
 

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -49,7 +49,7 @@ namespace costmap_2d
 
 LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown) :
     timestep_(0.1),
-    prediction_time_(1.6),
+    prediction_time_(3.0),
     global_frame_(global_frame),
     rolling_window_(rolling_window),
     current_(false),

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -122,7 +122,7 @@ namespace dwa_local_planner {
 
   DWAPlanner::DWAPlanner(std::string name, base_local_planner::LocalPlannerUtil *planner_util) :
       planner_util_(planner_util),
-      obstacle_costs_(planner_util->getTimedCostmaps()),
+      obstacle_costs_(planner_util->getLayeredCostmap()),
       path_costs_(planner_util->getCostmap()),
       goal_costs_(planner_util->getCostmap(), 0.0, 0.0, true),
       goal_front_costs_(planner_util->getCostmap(), 0.0, 0.0, true),

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -502,8 +502,8 @@ namespace dwa_local_planner {
         unsigned int num_points = 0;
         for(std::vector<base_local_planner::Trajectory>::iterator t=all_explored.begin(); t != all_explored.end(); ++t)
         {
-            // if (t->cost_<0)
-            //   continue;
+            if (t->cost_<0)
+              continue;
             num_points += t->getPointsSize();
         }
 
@@ -511,8 +511,8 @@ namespace dwa_local_planner {
         sensor_msgs::PointCloud2Iterator<float> iter_x(traj_cloud, "x");
         for(std::vector<base_local_planner::Trajectory>::iterator t=all_explored.begin(); t != all_explored.end(); ++t)
         {
-            // if(t->cost_<0)
-            //     continue;
+            if(t->cost_<0)
+                continue;
             // Fill out the plan
             for(unsigned int i = 0; i < t->getPointsSize(); ++i) {
                 double p_x, p_y, p_th;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -122,7 +122,7 @@ namespace dwa_local_planner {
 
   DWAPlanner::DWAPlanner(std::string name, base_local_planner::LocalPlannerUtil *planner_util) :
       planner_util_(planner_util),
-      obstacle_costs_(planner_util->getCostmap()),
+      obstacle_costs_(planner_util->getTimedCostmaps()),
       path_costs_(planner_util->getCostmap()),
       goal_costs_(planner_util->getCostmap(), 0.0, 0.0, true),
       goal_front_costs_(planner_util->getCostmap(), 0.0, 0.0, true),
@@ -502,8 +502,8 @@ namespace dwa_local_planner {
         unsigned int num_points = 0;
         for(std::vector<base_local_planner::Trajectory>::iterator t=all_explored.begin(); t != all_explored.end(); ++t)
         {
-            if (t->cost_<0)
-              continue;
+            // if (t->cost_<0)
+            //   continue;
             num_points += t->getPointsSize();
         }
 
@@ -511,8 +511,8 @@ namespace dwa_local_planner {
         sensor_msgs::PointCloud2Iterator<float> iter_x(traj_cloud, "x");
         for(std::vector<base_local_planner::Trajectory>::iterator t=all_explored.begin(); t != all_explored.end(); ++t)
         {
-            if(t->cost_<0)
-                continue;
+            // if(t->cost_<0)
+            //     continue;
             // Fill out the plan
             for(unsigned int i = 0; i < t->getPointsSize(); ++i) {
                 double p_x, p_y, p_th;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -128,10 +128,10 @@ namespace dwa_local_planner {
 
       // make sure to update the costmap we'll use for this cycle
       costmap_2d::Costmap2D* costmap = costmap_ros_->getCostmap();
-      std::vector<costmap_2d::Costmap2D>* timed_costmaps = costmap_ros_->getTimedCostmaps();
+      costmap_2d::LayeredCostmap* layered_costmap = costmap_ros_->getLayeredCostmap();
 
 
-      planner_util_.initialize(tf, costmap, timed_costmaps, costmap_ros_->getGlobalFrameID());
+      planner_util_.initialize(tf, costmap, layered_costmap, costmap_ros_->getGlobalFrameID());
 
       //create the actual planner that we'll use.. it'll configure itself from the parameter server
       dp_ = boost::shared_ptr<DWAPlanner>(new DWAPlanner(name, &planner_util_));

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -131,7 +131,7 @@ namespace dwa_local_planner {
       costmap_2d::LayeredCostmap* layered_costmap = costmap_ros_->getLayeredCostmap();
 
 
-      planner_util_.initialize(tf, costmap, layered_costmap, costmap_ros_->getGlobalFrameID());
+      planner_util_.initialize(tf, layered_costmap, costmap_ros_->getGlobalFrameID());
 
       //create the actual planner that we'll use.. it'll configure itself from the parameter server
       dp_ = boost::shared_ptr<DWAPlanner>(new DWAPlanner(name, &planner_util_));

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -127,7 +127,6 @@ namespace dwa_local_planner {
       costmap_ros_->getRobotPose(current_pose_);
 
       // make sure to update the costmap we'll use for this cycle
-      costmap_2d::Costmap2D* costmap = costmap_ros_->getCostmap();
       costmap_2d::LayeredCostmap* layered_costmap = costmap_ros_->getLayeredCostmap();
 
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -128,8 +128,10 @@ namespace dwa_local_planner {
 
       // make sure to update the costmap we'll use for this cycle
       costmap_2d::Costmap2D* costmap = costmap_ros_->getCostmap();
+      std::vector<costmap_2d::Costmap2D>* timed_costmaps = costmap_ros_->getTimedCostmaps();
 
-      planner_util_.initialize(tf, costmap, costmap_ros_->getGlobalFrameID());
+
+      planner_util_.initialize(tf, costmap, timed_costmaps, costmap_ros_->getGlobalFrameID());
 
       //create the actual planner that we'll use.. it'll configure itself from the parameter server
       dp_ = boost::shared_ptr<DWAPlanner>(new DWAPlanner(name, &planner_util_));
@@ -394,6 +396,7 @@ namespace dwa_local_planner {
   uint32_t DWAPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
                                                   const geometry_msgs::TwistStamped& velocity,
                                                   geometry_msgs::TwistStamped& cmd_vel, std::string& message) {
+    
     // dispatches to either dwa sampling control or stop and rotate control, depending on whether we have been close enough to goal
     if ( ! costmap_ros_->getRobotPose(current_pose_)) {
       message = "Could not get robot pose";


### PR DESCRIPTION
## :clock1: Idea    

This is a PoC for the Timed Costmap approach discussed in the Dynamic Obstacle meetings. The basic idea is to augment the costmap with time information, basically extending it by another dimension, so that the planners can plan in space _and_ time and thus handle dynamic obstacles. For this we want to precompute the costs at future times so that the planners can consider them when choosing trajectories.

 ## :clock2:    Implementation  
In this implementation we create a vector of costmaps `std::vector<costmap_2d::Costmap2D> timed_costmaps_` inside the [LayeredCostmaps](http://docs.ros.org/en/noetic/api/costmap_2d/html/classcostmap__2d_1_1Layer.html) class and get rid of the single Costmap2D object `costmap_`. Inside `updateMap()` we then loop through these costmaps and update each one of them given some time argument. In the Layer class we overload the `updateBounds` and `updateCosts` functions to take a time argument t, but default them to call the previous function without time, so that the normal Layers aren't affected. However, the Dynamic Obstacle Layer can take this time argument to displace the obstacles. The LayeredCostmap object is then passed to the `ObstacleCostFunction`.

DWA generates trajectories by sampling different linear and angular velocities. When scoring these trajectories, we calculate the cost of points on that trajectory at a certain time interval `time_delta_` that defines the gap between the points. This means that the time for each point is given by its index and the time interval:  `t = i*time_delta_`

When the planner calls the `footprintCost()` function inside the `ObstacleCostFunction` class, we can then pass this time argument. For calculating the Cost we then simply use the costmap inside the `timed_costmaps_` vector that corresponds to the given time t! :balloon: 


## :clock3: Comparison of Approaches

Since we have a few different components that can be combined in different ways with a lot of tunable parameters here is a first comparison of the different approaches. For this I wrote a short python script that sends the robot back and forth and creates 3 obstacles that cross its path. I then let the script run for 2 minutes for each configuration and 'measured' some metrics displayed in the table at the end. First i'll explain the configurations tested...

**1. No dynamic obstacle handling**
No explenation needed, we've all seen this one. If the obstacle does not avoid the robot, it will collide. :boom: 

**2. Original Dynamic Obstacle Layer** 
A Dynamic Obstacle Layer Approach implemented [here](https://github.com/links-cosero/navigation2_dynamic/tree/fba573f2afdadb8e49cec888fd95c1e26406785a/nav2_gradient_costmap_plugin) simply creates a 2D gaussian shape around the obstacles, extending them forward. For testing I used the original parameters.

**3. Improved Dynamic Obstacle Layer** 
This approach was discussed in https://github.com/rapyuta-robotics/rr_navigation/pull/1407). The idea is to take the 2D Gaussian shape created in [2](https://github.com/rapyuta-robotics/ros-navigation/assets/62353963/26a33485-072a-47e0-8738-d3491e925d64) but displace the center to the earliest point on the obstacles trajectory that the robot could collide with it (considering its current pose and maximum speed). For this approach there are a lot of parameters that affect the performance and can be tuned to achieve different behaviors. For testing I ran it once with the original DOL parameters (IDOL0), once with a smaller gaussian shape (IDOL1) and once with a bigger one (IDOL2)
Note, that in the videos the actual obstacles are visualized by the arrows/frames, the lethal costs obstacles are the virtual displaced ones! 

https://github.com/rapyuta-robotics/ros-navigation/assets/62353963/4e0b1860-b506-4b76-b585-ac32e3583dfa

**4. Local Costmap only...**
For the Timed Costmap approach I created a timed _local_ costmap only and don't add the dynamic obstacles to the global costmap. For a fair comparison this configuration (painting obstacles only on the local costmap) was also tested without the timed costmap and showed surprisingly good results. I tested this once with `sim_time = 1.2s` (Only Local 1) and once with `sim_time = 2.0s` (Only Local 2).


**5. Timed Costmap!**
Finally, if you put all the previous approaches together you get the promised timed costmap. This was also tested once with `sim_time = 1.2s` (Timed 1) and once with `sim_time = 2.0s` (Timed 2). 

https://github.com/rapyuta-robotics/ros-navigation/assets/62353963/e8a577b2-ba7d-4977-8aa1-abf49a4219b3
<div dir="ltr" style="margin-left:-69pt;" align="left" id="docs-internal-guid-267fa005-7fff-d1c4-1443-f25994a3d5d0">

In the table below you can see the results I got. 

  | Current | Only Local 1 | Only Local 2 | DOL | IDOL 0 | IDOL 1 | IDOL 2 | Timed Map 1 | Timed Map 2
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Coll. | 2 | 2 | 1 | 2 | 1 |   | 2 |   |  
Almost coll. * | 1 | 1 | 3 | 5 | 1 | 1 |   | 1 | 1
Weird rotations* | 5 |   |   | 5 | 1 | 2 | 2 | 3 | 1
Speeding up & stopping* |   | 6 | 6 | 3 | 2 |   |   |   |  
timeout* | 1 |   |   |   |   | 3 |   |   |  
Goals reached | 7 | 7 | 5 | 7 | 9 | 4 | 8 | 8 | 7
Distance to lethal* | medium | low | low | low | medium | medium | medium | medium | medium

</div><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">*Note that these are kinda subjective and I tend to be very biased in my judgement… :innocent:  </span></p>

## :clock4: Results & Next Steps

So... I think we have some promising approaches here. Personally, I think the Timed Costmap really looked the most beautiful and behaves the most natural. In the video below, where I ran the Timed Costmap with `sim_time_ = 3`, you can see how the robot waits for the obstacles to pass or even moves out of the way when the obstacles are coming towards it, but doesn't slow down when the obstacles are moving out of its way. 

https://github.com/rapyuta-robotics/ros-navigation/assets/62353963/7e0cd585-411a-404b-a00e-d55b321b2b87

However, it is definitely the most complex both in implementation and computational efforts...
The DOL works really well with single obstacles, but with multiple obstacles the global planner starts having issues if the gaussian shapes are too big (if they are too small we get weird rotations and even collisions). For the DOL the behavior really depends a lot on the chosen parameters, but all in all, it successfully avoids obstacles but the navigation is less elegant and less intuitive compared to the Timed Costmap. The Timed Costmap and DOL could also be combined in different ways, for example we could use the timed costmap (number 5) together with the collision time displacement (number 3) for the global costmap etc. For all the approaches a lot of parameter tuning and optimization is necessary... 

## Please leave some comments and thoughts (otherwise ill schedule another Dynamic Obstacle Discussion! :smiling_imp: )

