### PR TITLE
Visualize Costmaps when jumping back in ROS time

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -263,7 +263,6 @@ private:
   boost::thread* map_update_thread_;  ///< @brief A thread for updating the map
   ros::Timer timer_;
   ros::Time last_publish_;
-  ros::Time prev_;
   ros::Duration publish_cycle;
   pluginlib::ClassLoader<Layer> plugin_loader_;
   geometry_msgs::PoseStamped old_pose_;

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -263,6 +263,7 @@ private:
   boost::thread* map_update_thread_;  ///< @brief A thread for updating the map
   ros::Timer timer_;
   ros::Time last_publish_;
+  ros::Time prev_;
   ros::Duration publish_cycle;
   pluginlib::ClassLoader<Layer> plugin_loader_;
   geometry_msgs::PoseStamped old_pose_;

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -463,14 +463,16 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       unsigned int x0, y0, xn, yn;
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
       publisher_->updateBounds(x0, xn, y0, yn);
-
       ros::Time now = ros::Time::now();
-      if (last_publish_ + publish_cycle < now)
+      ROS_WARN_COND(now < prev_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (prev_.toSec()-now.toSec()));
+      if (now < prev_ || last_publish_ + publish_cycle < now)
       {
         publisher_->publishCostmap();
         last_publish_ = now;
       }
+      prev_ = now;
     }
+  
     r.sleep();
     // make sure to sleep for the remainder of our cycle time
     if (r.cycleTime() > ros::Duration(1 / frequency))

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -463,14 +463,14 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       unsigned int x0, y0, xn, yn;
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
       publisher_->updateBounds(x0, xn, y0, yn);
+
       ros::Time now = ros::Time::now();
-      ROS_WARN_COND(now < prev_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (prev_.toSec()-now.toSec()));
-      if (now < prev_ || last_publish_ + publish_cycle < now)
+      ROS_WARN_COND(now < last_publish_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (last_publish_.toSec()-now.toSec()));
+      if (now < last_publish_ || last_publish_ + publish_cycle < now)
       {
         publisher_->publishCostmap();
         last_publish_ = now;
       }
-      prev_ = now;
     }
   
     r.sleep();

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -465,14 +465,13 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       publisher_->updateBounds(x0, xn, y0, yn);
 
       ros::Time now = ros::Time::now();
-      ROS_WARN_COND(now < last_publish_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (last_publish_.toSec()-now.toSec()));
+      ROS_WARN_COND(now < last_publish_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (last_publish_ - now).toSec());
       if (now < last_publish_ || last_publish_ + publish_cycle < now)
       {
         publisher_->publishCostmap();
         last_publish_ = now;
       }
     }
-  
     r.sleep();
     // make sure to sleep for the remainder of our cycle time
     if (r.cycleTime() > ros::Duration(1 / frequency))


### PR DESCRIPTION
This commit is needed for the visualize_costmap tool introduced in this PR:
- https://github.com/rapyuta-robotics/rr_navigation/pull/1438 

To visualize the costmaps when skipping forward and backward in bagfiles with Plotjuggler the costmaps also need to be published when ros time jumps backwards.