### PR TITLE
Scale left and right sides of the footprint independently

### DIFF
--- a/base_local_planner/include/base_local_planner/obstacle_cost_function.h
+++ b/base_local_planner/include/base_local_planner/obstacle_cost_function.h
@@ -85,8 +85,10 @@ private:
   //footprint scaling with velocity;
   double max_forward_inflation_, max_sideward_inflation_, scaling_speed_;
 
-  ros::Subscriber sideward_inflation_scale_sub_;
-  std::atomic<double> sideward_inflation_scale_;
+  ros::Subscriber sideward_inflation_scale_left_sub_;
+  ros::Subscriber sideward_inflation_scale_right_sub_;
+  std::atomic<double> sideward_inflation_scale_left_;
+  std::atomic<double> sideward_inflation_scale_right_;
   bool occdist_use_footprint_;
   double scaling_discount_factor_;
 };

--- a/base_local_planner/src/obstacle_cost_function.cpp
+++ b/base_local_planner/src/obstacle_cost_function.cpp
@@ -45,14 +45,17 @@
 namespace base_local_planner {
 
 ObstacleCostFunction::ObstacleCostFunction(costmap_2d::Costmap2D* costmap)
-    : costmap_(costmap), sum_scores_(false), sideward_inflation_scale_(1.0) {
+    : costmap_(costmap), sum_scores_(false), sideward_inflation_scale_left_(1.0), sideward_inflation_scale_right_(1.0) {
   if (costmap != NULL) {
     world_model_ = new base_local_planner::CostmapModel(*costmap_);
   }
 
-  ros::NodeHandle pnh("~");
-  sideward_inflation_scale_sub_ = pnh.subscribe<std_msgs::Float32>("sideward_inflation_scale", 1, [&](const std_msgs::Float32ConstPtr& msg){
-    sideward_inflation_scale_ = msg->data;
+  ros::NodeHandle vis_nh("visibility_reconfig");
+  sideward_inflation_scale_left_sub_ = vis_nh.subscribe<std_msgs::Float32>("sideward_inflation_scale_left", 1, [&](const std_msgs::Float32ConstPtr& msg){
+    sideward_inflation_scale_left_ = msg->data;
+  });
+  sideward_inflation_scale_right_sub_ = vis_nh.subscribe<std_msgs::Float32>("sideward_inflation_scale_right", 1, [&](const std_msgs::Float32ConstPtr& msg){
+    sideward_inflation_scale_right_ = msg->data;
   });
 }
 
@@ -90,11 +93,15 @@ std::vector<geometry_msgs::Point> ObstacleCostFunction::getScaledFootprint(const
   if (scale != 0.0) {
     const bool fwd = traj.xv_ > 0;
     const double forward_inflation = scale * max_forward_inflation_;
-    const double sideward_inflation = scale * sideward_inflation_scale_ * max_sideward_inflation_;
     for (unsigned int i = 0; i < scaled_footprint.size(); ++i) {
       if (fwd == (scaled_footprint[i].x > 0)) {
         // assumes no sideward motion
         scaled_footprint[i].x += std::copysign(forward_inflation, scaled_footprint[i].x);
+
+        const double sideward_inflation = scaled_footprint[i].y > 0 ?
+                                              scale * sideward_inflation_scale_left_ * max_sideward_inflation_ :
+                                              scale * sideward_inflation_scale_right_ * max_sideward_inflation_;
+
         // assumes the widest part of the robot is not behind the footprint's origin
         scaled_footprint[i].y += std::copysign(sideward_inflation, scaled_footprint[i].y);
       }


### PR DESCRIPTION
## Description

Scale left and right sides of the footprint independently.

**Dependencies:**
- https://github.com/rapyuta-robotics/rr_navigation/pull/1793

## Demo

Notice how the side of the footprint with bad visibility keeps changing sizes while the other side is constant.
The terminal on top shows the left scale (I just noticed it's not scrolling down and showing the new values... :sweat_smile:), and the terminal on the bottom shows the right scale.

https://github.com/rapyuta-robotics/ros-navigation/assets/15384781/9e7ca231-de89-4b84-a45b-121fa9624af5