### PR TITLE
Publish update bounds

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -65,6 +65,12 @@ public:
   /** @brief Include the given bounds in the changed-rectangle. */
   void updateBounds(unsigned int x0, unsigned int xn, unsigned int y0, unsigned int yn)
   {
+    {
+      boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
+      costmap_->mapToWorld(x0, y0, last_min_x_, last_min_y_);
+      costmap_->mapToWorld(xn, yn, last_max_x_, last_max_y_);
+    }
+
     x0_ = std::min(x0, x0_);
     xn_ = std::max(xn, xn_);
     y0_ = std::min(y0, y0_);
@@ -75,6 +81,11 @@ public:
    * @brief  Publishes the visualization data over ROS
    */
   void publishCostmap();
+
+  /**
+   * @brief Publishes the bounds of the latest costmap update.
+   */
+  void publishBounds();
 
   /**
    * @brief Check if the publisher is active
@@ -96,11 +107,13 @@ private:
   Costmap2D* costmap_;
   std::string global_frame_;
   unsigned int x0_, xn_, y0_, yn_;
+  double last_min_x_, last_max_x_, last_min_y_, last_max_y_;
   double saved_origin_x_, saved_origin_y_;
   bool active_;
   bool always_send_full_costmap_;
   ros::Publisher costmap_pub_;
   ros::Publisher costmap_update_pub_;
+  ros::Publisher bounds_pub_;
   nav_msgs::OccupancyGrid grid_;
   static char* cost_translation_table_;  ///< Translate from 0-255 values in costmap to -1 to 100 values in message.
 };

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -38,6 +38,7 @@
 #include <boost/bind.hpp>
 #include <costmap_2d/costmap_2d_publisher.h>
 #include <costmap_2d/cost_values.h>
+#include <geometry_msgs/PolygonStamped.h>
 
 namespace costmap_2d
 {
@@ -52,6 +53,7 @@ Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* co
   costmap_pub_ = ros_node->advertise<nav_msgs::OccupancyGrid>(topic_name, 1,
                                                     boost::bind(&Costmap2DPublisher::onNewSubscription, this, _1));
   costmap_update_pub_ = ros_node->advertise<map_msgs::OccupancyGridUpdate>(topic_name + "_updates", 1);
+  bounds_pub_ = ros_node->advertise<geometry_msgs::PolygonStamped>(topic_name + "_bounds", 1);
 
   if (cost_translation_table_ == NULL)
   {
@@ -74,6 +76,9 @@ Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* co
   xn_ = yn_ = 0;
   x0_ = costmap_->getSizeInCellsX();
   y0_ = costmap_->getSizeInCellsY();
+  last_max_x_ = last_max_y_ = 0;
+  last_min_x_ = costmap_->getSizeInMetersX();
+  last_min_y_ = costmap_->getSizeInMetersY();
 }
 
 Costmap2DPublisher::~Costmap2DPublisher()
@@ -164,6 +169,33 @@ void Costmap2DPublisher::publishCostmap()
   xn_ = yn_ = 0;
   x0_ = costmap_->getSizeInCellsX();
   y0_ = costmap_->getSizeInCellsY();
+}
+
+void Costmap2DPublisher::publishBounds()
+{
+  if (bounds_pub_.getNumSubscribers() == 0 || last_max_x_ < last_min_x_ || last_max_y_ < last_min_y_)
+  {
+    return;
+  }
+
+  geometry_msgs::PolygonStamped msg;
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = global_frame_;
+  msg.polygon.points.resize(4);
+
+  msg.polygon.points[0].x = last_min_x_;
+  msg.polygon.points[0].y = last_min_y_;
+
+  msg.polygon.points[1].x = last_min_x_;
+  msg.polygon.points[1].y = last_max_y_;
+
+  msg.polygon.points[2].x = last_max_x_;
+  msg.polygon.points[2].y = last_max_y_;
+
+  msg.polygon.points[3].x = last_max_x_;
+  msg.polygon.points[3].y = last_min_y_;
+
+  bounds_pub_.publish(msg);
 }
 
 }  // end namespace costmap_2d

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -447,7 +447,7 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
     double start_t, end_t, t_diff;
     gettimeofday(&start, NULL);
     #endif
-    
+
     updateMap();
 
     #ifdef HAVE_SYS_TIME_H
@@ -457,7 +457,7 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
     t_diff = end_t - start_t;
     ROS_DEBUG("Map update time: %.9f", t_diff);
     #endif
-    
+
     if (publish_cycle.toSec() > 0 && layered_costmap_->isInitialized())
     {
       unsigned int x0, y0, xn, yn;
@@ -469,6 +469,7 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       if (now < last_publish_ || last_publish_ + publish_cycle < now)
       {
         publisher_->publishCostmap();
+        publisher_->publishBounds();
         last_publish_ = now;
       }
     }


### PR DESCRIPTION
## Description

Add a publisher for the update bounds of the costmap.
This is helpful for debugging if any layer is misbehaving or wrongly computing the bounds resulting in wasted computation.

## Demo

Global update bounds in yellow, local update bounds in white.
At the end of the video you can see we update the entire costmap -- that's because we clear the costmaps when navigation ends.

https://github.com/rapyuta-robotics/ros-navigation/assets/15384781/46c0d84d-bdf6-407d-80cc-c738cd61e9e6