### PR TITLE
Fix costmap update not being published on force updates

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -460,10 +460,6 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
 
     if (publish_cycle.toSec() > 0 && layered_costmap_->isInitialized())
     {
-      unsigned int x0, y0, xn, yn;
-      layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
-      publisher_->updateBounds(x0, xn, y0, yn);
-
       ros::Time now = ros::Time::now();
       ROS_WARN_COND(now < last_publish_, "ROS Time jumped backwards by %.3f s. Publishing costmaps anyway.", (last_publish_ - now).toSec());
       if (now < last_publish_ || last_publish_ + publish_cycle < now)
@@ -503,6 +499,13 @@ void Costmap2DROS::updateMap()
 
       initialized_ = true;
     }
+  }
+
+  if (publish_cycle.toSec() > 0 && layered_costmap_->isInitialized())
+  {
+    unsigned int x0, y0, xn, yn;
+    layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
+    publisher_->updateBounds(x0, xn, y0, yn);
   }
 }
 


### PR DESCRIPTION
## Description

`Costmap2DROS::updateMap` is a public method that other components can call to force an update to happen outside of the usual `Costmap2DROS::mapUpdateLoop`.

Since `Costmap2DPublisher::updateBounds` is only called inside `Costmap2DROS::mapUpdateLoop`, this means that when forcing a costmap update we are not updating the bounds of the publisher and thus will result in wrong visualization.

To fix this, we have to ensure the bounds of the publisher are also updated on force updates.
This can be achieved by moving the logic for updating the publisher bounds to be inside `Costmap2DROS::updateMap`.

Notice in the video below how there's wrong information remaining in the costmap after a force update.
This PR fixes that.

https://github.com/rapyuta-robotics/ros-navigation/assets/15384781/d8f49e0e-8e80-43b3-9731-29b9dc828af7