### PR TITLE
Add raytrace outside the map

### DIFF
--- a/costmap_2d/cfg/ObstaclePlugin.cfg
+++ b/costmap_2d/cfg/ObstaclePlugin.cfg
@@ -7,7 +7,7 @@ gen = ParameterGenerator()
 gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
 gen.add("footprint_clearing_enabled", bool_t, 0, "Whether to clear the robot's footprint of lethal obstacles", True)
 gen.add("max_obstacle_height", double_t, 0, "The maximum height of any obstacle to be inserted into the costmap in meters.", 2, 0, 50)
-gen.add("raytrace_outside_map", bool_t, 0, "Whether to raytrace when sensor is outside map or not", False)
+gen.add("raytrace_outside_map", bool_t, 0, "Whether to raytrace when the sensor is outside the map", False)
 
 combo_enum = gen.enum([gen.const("Overwrite", int_t,  0, "Overwrite values"),
                        gen.const("Maximum",   int_t,  1, "Take the maximum of the values"),

--- a/costmap_2d/cfg/ObstaclePlugin.cfg
+++ b/costmap_2d/cfg/ObstaclePlugin.cfg
@@ -7,6 +7,7 @@ gen = ParameterGenerator()
 gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
 gen.add("footprint_clearing_enabled", bool_t, 0, "Whether to clear the robot's footprint of lethal obstacles", True)
 gen.add("max_obstacle_height", double_t, 0, "The maximum height of any obstacle to be inserted into the costmap in meters.", 2, 0, 50)
+gen.add("raytrace_outside_map", bool_t, 0, "Whether to raytrace when sensor is outside map or not", False)
 
 combo_enum = gen.enum([gen.const("Overwrite", int_t,  0, "Overwrite values"),
                        gen.const("Maximum",   int_t,  1, "Take the maximum of the values"),

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -154,7 +154,7 @@ protected:
                                  double* max_x, double* max_y);
 
   /**
-   * @brief Adjust the origin of the sensor to be inside the map
+   * @brief Adjust the origin of the sensor to be inside the map if raytrace_outside_map is true.
    * When the sensor origin is outside the map, we calculate where the line
    * between the origin and the point intersects the map boundaries.
    * This becomes the new start point for the raytrace

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -158,7 +158,6 @@ protected:
    * When the sensor origin is outside the map, we calculate where the line
    * between the origin and the point intersects the map boundaries.
    * This becomes the new start point for the raytrace.
-   * The endpoint is also updated if it is outside the map, as the other intersection point.
    * It returns true if the new origin is updated, within range, and closer than the endpoint
    * @param ox The x coordinate of the origin
    * @param oy The y coordinate of the origin
@@ -166,7 +165,7 @@ protected:
    * @param wy The y coordinate of the point
    * @return bool True if the origin is updated
    */
-  bool adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double& wx, double& wy) const;
+  bool adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx, double wy) const;
 
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
                             double* max_x, double* max_y);

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -56,11 +56,23 @@
 #include <costmap_2d/ObstaclePluginConfig.h>
 #include <costmap_2d/footprint.h>
 
+// boost
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
 namespace costmap_2d
 {
 
+namespace bg = boost::geometry;
+
 class ObstacleLayer : public CostmapLayer
 {
+private:
+  typedef bg::model::d2::point_xy<double> Point;
+  typedef bg::model::polygon<Point, false, false> Polygon;
+  typedef bg::model::linestring<Point> Linestring;
 public:
   ObstacleLayer()
   {
@@ -141,8 +153,28 @@ protected:
   virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation, double* min_x, double* min_y,
                                  double* max_x, double* max_y);
 
+  /**
+   * @brief Adjust the origin of the sensor to be inside the map
+   * When the sensor origin is outside the map, we calculate where the line
+   * between the origin and the point intersects the map boundaries.
+   * This becomes the new start point for the raytrace
+   * @param ox The x coordinate of the origin
+   * @param oy The y coordinate of the origin
+   * @param wx The x coordinate of the point
+   * @param wy The y coordinate of the point
+   * @return bool True if the origin is updated
+   */
+  bool adjustSensorOrigin(double& ox, double& oy, double wx, double wy) const;
+
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
                             double* max_x, double* max_y);
+
+  /**
+   * @brief  Move the origin of the costmap to a new location.... keeping data when it can
+   * @param  new_origin_x The x coordinate of the new origin
+   * @param  new_origin_y The y coordinate of the new origin
+   */
+  virtual void updateOrigin(double new_origin_x, double new_origin_y);
 
   std::vector<geometry_msgs::Point> transformed_footprint_;
   bool footprint_clearing_enabled_;
@@ -167,6 +199,8 @@ protected:
   dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig> *dsrv_;
 
   int combination_method_;
+  bool raytrace_outside_map_;
+  Polygon map_boundary_;
 
 private:
   void reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level);

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -157,14 +157,15 @@ protected:
    * @brief Adjust the origin of the sensor to be inside the map if raytrace_outside_map is true.
    * When the sensor origin is outside the map, we calculate where the line
    * between the origin and the point intersects the map boundaries.
-   * This becomes the new start point for the raytrace
+   * This becomes the new start point for the raytrace.
+   * It returns true if the new origin is updated, within range, and closer than the endpoint
    * @param ox The x coordinate of the origin
    * @param oy The y coordinate of the origin
    * @param wx The x coordinate of the point
    * @param wy The y coordinate of the point
    * @return bool True if the origin is updated
    */
-  bool adjustSensorOrigin(double& ox, double& oy, double wx, double wy) const;
+  bool adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx, double wy) const;
 
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
                             double* max_x, double* max_y);

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -169,17 +169,11 @@ protected:
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
                             double* max_x, double* max_y);
 
-  /**
-   * @brief  Move the origin of the costmap to a new location.... keeping data when it can
-   * @param  new_origin_x The x coordinate of the new origin
-   * @param  new_origin_y The y coordinate of the new origin
-   */
-  virtual void updateOrigin(double new_origin_x, double new_origin_y);
   void updateMapPolygon();
 
   std::vector<geometry_msgs::Point> transformed_footprint_;
   bool footprint_clearing_enabled_;
-  void updateFootprint(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, 
+  void updateFootprint(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                        double* max_x, double* max_y);
 
   std::string global_frame_;  ///< @brief The global frame for the costmap

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -175,6 +175,7 @@ protected:
    * @param  new_origin_y The y coordinate of the new origin
    */
   virtual void updateOrigin(double new_origin_x, double new_origin_y);
+  void updateMapPolygon();
 
   std::vector<geometry_msgs::Point> transformed_footprint_;
   bool footprint_clearing_enabled_;

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -158,6 +158,7 @@ protected:
    * When the sensor origin is outside the map, we calculate where the line
    * between the origin and the point intersects the map boundaries.
    * This becomes the new start point for the raytrace.
+   * The endpoint is also updated if it is outside the map, as the other intersection point.
    * It returns true if the new origin is updated, within range, and closer than the endpoint
    * @param ox The x coordinate of the origin
    * @param oy The y coordinate of the origin
@@ -165,7 +166,7 @@ protected:
    * @param wy The y coordinate of the point
    * @return bool True if the origin is updated
    */
-  bool adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx, double wy) const;
+  bool adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double& wx, double& wy) const;
 
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
                             double* max_x, double* max_y);

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -506,19 +506,17 @@ bool ObstacleLayer::getClearingObservations(std::vector<Observation>& clearing_o
 void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, double* min_x, double* min_y,
                                               double* max_x, double* max_y)
 {
-  double ox = clearing_observation.origin_.x;
-  double oy = clearing_observation.origin_.y;
   const sensor_msgs::PointCloud2 &cloud = *(clearing_observation.cloud_);
 
   // get the map coordinates of the origin of the sensor
 
   unsigned int x0, y0;
-  const bool origin_valid = worldToMap(ox, oy, x0, y0);
+  const bool origin_valid = worldToMap(clearing_observation.origin_.x, clearing_observation.origin_.y, x0, y0);
   if (!origin_valid && !raytrace_outside_map_)
   {
     ROS_WARN_THROTTLE(
         1.0, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot raytrace for it.",
-        ox, oy);
+        clearing_observation.origin_.x, clearing_observation.origin_.y);
     return;
   }
 
@@ -527,7 +525,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   double map_end_x = origin_x + size_x_ * resolution_;
   double map_end_y = origin_y + size_y_ * resolution_;
 
-  touch(ox, oy, min_x, min_y, max_x, max_y);
+  touch(clearing_observation.origin_.x, clearing_observation.origin_.y, min_x, min_y, max_x, max_y);
 
   // for each point in the cloud, we want to trace a line from the origin and clear obstacles along it
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
@@ -535,6 +533,9 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 
   for (; iter_x != iter_x.end(); ++iter_x, ++iter_y)
   {
+    double ox = clearing_observation.origin_.x;
+    double oy = clearing_observation.origin_.y;
+
     double wx = *iter_x;
     double wy = *iter_y;
 
@@ -543,37 +544,39 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     {
       continue;
     }
-
-    // now we also need to make sure that the enpoint we're raytracing
-    // to isn't off the costmap and scale if necessary
-    double a = wx - ox;
-    double b = wy - oy;
-
-    // the minimum value to raytrace from is the origin
-    if (wx < origin_x)
+    else
     {
-      double t = (origin_x - ox) / a;
-      wx = origin_x;
-      wy = oy + b * t;
-    }
-    if (wy < origin_y)
-    {
-      double t = (origin_y - oy) / b;
-      wx = ox + a * t;
-      wy = origin_y;
-    }
-    // the maximum value to raytrace to is the end of the map
-    if (wx > map_end_x)
-    {
-      double t = (map_end_x - ox) / a;
-      wx = map_end_x - .001;
-      wy = oy + b * t;
-    }
-    if (wy > map_end_y)
-    {
-      double t = (map_end_y - oy) / b;
-      wx = ox + a * t;
-      wy = map_end_y - .001;
+      // now we also need to make sure that the enpoint we're raytracing
+      // to isn't off the costmap and scale if necessary
+      double a = wx - ox;
+      double b = wy - oy;
+  
+      // the minimum value to raytrace from is the origin
+      if (wx < origin_x)
+      {
+        double t = (origin_x - ox) / a;
+        wx = origin_x;
+        wy = oy + b * t;
+      }
+      if (wy < origin_y)
+      {
+        double t = (origin_y - oy) / b;
+        wx = ox + a * t;
+        wy = origin_y;
+      }
+      // the maximum value to raytrace to is the end of the map
+      if (wx > map_end_x)
+      {
+        double t = (map_end_x - ox) / a;
+        wx = map_end_x - .001;
+        wy = oy + b * t;
+      }
+      if (wy > map_end_y)
+      {
+        double t = (map_end_y - oy) / b;
+        wx = ox + a * t;
+        wy = map_end_y - .001;
+      }
     }
 
     // now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
@@ -592,8 +595,8 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   }
 }
 
-bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx,
-                                       double wy) const
+bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double& wx,
+                                       double& wy) const
 {
   // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
   Linestring sensor_ray;
@@ -620,17 +623,22 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   // copy original sensor origin
   const double original_ox = ox;
   const double original_oy = oy;
+  double end_x, end_y;
 
   // Choose the closest intersection point as origin
   if (distance1 < distance2)
   {
     ox = intersection1.x();
     oy = intersection1.y();
+    end_x = intersection2.x();
+    end_y = intersection2.y();
   }
   else
   {
     ox = intersection2.x();
     oy = intersection2.y();
+    end_x = intersection1.x();
+    end_y = intersection1.y();
   }
 
   // check if the distance between new origin and original sensor's origin is within range
@@ -645,6 +653,15 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   if (std::hypot(original_ox - wx, original_oy - wy) < std::hypot(original_ox - ox, original_oy - oy))
   {
     return false;
+  }
+
+  // scale the endpoint to the second intersection point 
+  // if the distance between the new origin and endpoint is greater than second intersection point and the new origin
+  // this means the endpoint is outside the map, so we put it on the second intersection point (inside the map)
+  if (std::hypot(end_x - ox, end_y - oy) < std::hypot(wx - ox, wy - oy))
+  {
+    wx = end_x;
+    wy = end_y;
   }
 
   return true;

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -331,12 +331,6 @@ void ObstacleLayer::pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& 
   buffer->unlock();
 }
 
-void ObstacleLayer::updateOrigin(double new_origin_x, double new_origin_y)
-{
-  Costmap2D::updateOrigin(new_origin_x, new_origin_y);
-  updateMapPolygon();
-}
-
 void ObstacleLayer::updateMapPolygon()
 {
   map_boundary_.clear();

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -240,6 +240,7 @@ void ObstacleLayer::reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint
   footprint_clearing_enabled_ = config.footprint_clearing_enabled;
   max_obstacle_height_ = config.max_obstacle_height;
   combination_method_ = config.combination_method;
+  raytrace_outside_map_ = config.raytrace_outside_map;
 }
 
 void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& message,
@@ -328,6 +329,21 @@ void ObstacleLayer::pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& 
   buffer->lock();
   buffer->bufferCloud(*message);
   buffer->unlock();
+}
+
+void ObstacleLayer::updateOrigin(double new_origin_x, double new_origin_y)
+{
+  Costmap2D::updateOrigin(new_origin_x, new_origin_y);
+
+  map_boundary_.clear();
+  const double origin_x = origin_x_, origin_y = origin_y_;
+  const double map_end_x = origin_x + size_x_ * resolution_;
+  const double map_end_y = origin_y + size_y_ * resolution_;
+  bg::append(map_boundary_.outer(), Point(origin_x, origin_y));
+  bg::append(map_boundary_.outer(), Point(map_end_x, origin_y));
+  bg::append(map_boundary_.outer(), Point(map_end_x, map_end_y));
+  bg::append(map_boundary_.outer(), Point(origin_x, map_end_y));
+  bg::append(map_boundary_.outer(), Point(origin_x, origin_y));
 }
 
 void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
@@ -495,14 +511,17 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   const sensor_msgs::PointCloud2 &cloud = *(clearing_observation.cloud_);
 
   // get the map coordinates of the origin of the sensor
+
   unsigned int x0, y0;
-  if (!worldToMap(ox, oy, x0, y0))
+  const bool origin_valid = worldToMap(ox, oy, x0, y0);
+  if (!raytrace_outside_map_ && !origin_valid)
   {
     ROS_WARN_THROTTLE(
         1.0, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot raytrace for it.",
         ox, oy);
     return;
   }
+
 
   // we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
   double origin_x = origin_x_, origin_y = origin_y_;
@@ -526,6 +545,11 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double a = wx - ox;
     double b = wy - oy;
 
+    if (!origin_valid && !adjustSensorOrigin(ox, oy, wx, wy))
+    {
+      continue;
+    }
+
     // the minimum value to raytrace from is the origin
     if (wx < origin_x)
     {
@@ -539,7 +563,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
       wx = ox + a * t;
       wy = origin_y;
     }
-
     // the maximum value to raytrace to is the end of the map
     if (wx > map_end_x)
     {
@@ -558,7 +581,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     unsigned int x1, y1;
 
     // check for legality just in case
-    if (!worldToMap(wx, wy, x1, y1))
+    if (!worldToMap(wx, wy, x1, y1) || !worldToMap(ox, oy, x0, y0))
       continue;
 
     unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
@@ -569,6 +592,41 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
   }
 }
+
+bool ObstacleLayer::adjustSensorOrigin(double &ox, double &oy, double wx, double wy) const
+{
+  // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
+  Linestring sensor_ray;
+  bg::append(sensor_ray, Point(ox, oy));
+  bg::append(sensor_ray, Point(wx, wy));
+
+  std::vector<Point> intersection_points;
+  bg::intersection(sensor_ray, map_boundary_, intersection_points);
+
+  if (intersection_points.size() != 2)
+  {
+    return false;
+  }
+
+  const auto& intersection1 = intersection_points[0];
+  const auto& intersection2 = intersection_points[1];
+  double distance1 = bg::distance(Point(ox, oy), intersection1);
+  double distance2 = bg::distance(Point(ox, oy), intersection2);
+
+  // Choose the closest intersection point as origin
+  if (distance1 < distance2)
+  {
+    ox = intersection1.x();
+    oy = intersection1.y();
+  }
+  else
+  {
+    ox = intersection2.x();
+    oy = intersection2.y();
+  }
+  return true;
+}
+
 
 void ObstacleLayer::activate()
 {

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -539,7 +539,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double wy = *iter_y;
 
     // adjust the origin of the sensor to be inside the map if it is outside and raytrace_outside_map is true
-    if (!origin_valid && !adjustSensorOrigin(ox, oy, wx, wy))
+    if (!origin_valid && !adjustSensorOrigin(clearing_observation, ox, oy, wx, wy))
     {
       continue;
     }
@@ -592,7 +592,8 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   }
 }
 
-bool ObstacleLayer::adjustSensorOrigin(double& ox, double& oy, double wx, double wy) const
+bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx,
+                                       double wy) const
 {
   // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
   Linestring sensor_ray;
@@ -616,6 +617,10 @@ bool ObstacleLayer::adjustSensorOrigin(double& ox, double& oy, double wx, double
   double distance1 = bg::distance(Point(ox, oy), intersection1);
   double distance2 = bg::distance(Point(ox, oy), intersection2);
 
+  // copy original sensor origin
+  const double original_ox = ox;
+  const double original_oy = oy;
+
   // Choose the closest intersection point as origin
   if (distance1 < distance2)
   {
@@ -627,6 +632,21 @@ bool ObstacleLayer::adjustSensorOrigin(double& ox, double& oy, double wx, double
     ox = intersection2.x();
     oy = intersection2.y();
   }
+
+  // check if the distance between new origin and original sensor's origin is within range
+  if (std::hypot(original_ox - ox, original_oy - oy) > clearing_observation.raytrace_range_)
+  {
+    return false;
+  }
+
+  // check if the distance between the original sensor origin and the new one
+  // is greater than original sensor's origin and the endpoint
+  // the obstacle is closer than the map boundary, so we don't need to raytrace
+  if (std::hypot(original_ox - wx, original_oy - wy) < std::hypot(original_ox - ox, original_oy - oy))
+  {
+    return false;
+  }
+
   return true;
 }
 
@@ -654,10 +674,10 @@ void ObstacleLayer::deactivate()
   }
 }
 
-void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range,
-                                         double* min_x, double* min_y, double* max_x, double* max_y)
+void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x,
+                                         double* min_y, double* max_x, double* max_y)
 {
-  double dx = wx-ox, dy = wy-oy;
+  double dx = wx - ox, dy = wy - oy;
   double full_distance = hypot(dx, dy);
   double scale = std::min(1.0, range / full_distance);
   double ex = ox + dx * scale, ey = oy + dy * scale;
@@ -666,10 +686,10 @@ void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double
 
 void ObstacleLayer::reset()
 {
-    deactivate();
-    resetMaps();
-    current_ = true;
-    activate();
+  deactivate();
+  resetMaps();
+  current_ = true;
+  activate();
 }
 
 }  // namespace costmap_2d

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -514,7 +514,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 
   unsigned int x0, y0;
   const bool origin_valid = worldToMap(ox, oy, x0, y0);
-  if (!raytrace_outside_map_ && !origin_valid)
+  if (!origin_valid && !raytrace_outside_map_)
   {
     ROS_WARN_THROTTLE(
         1.0, "The origin for the sensor at (%.2f, %.2f) is out of map bounds. So, the costmap cannot raytrace for it.",
@@ -527,7 +527,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   double map_end_x = origin_x + size_x_ * resolution_;
   double map_end_y = origin_y + size_y_ * resolution_;
 
-
   touch(ox, oy, min_x, min_y, max_x, max_y);
 
   // for each point in the cloud, we want to trace a line from the origin and clear obstacles along it
@@ -539,6 +538,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double wx = *iter_x;
     double wy = *iter_y;
 
+    // adjust the origin of the sensor to be inside the map if it is outside and raytrace_outside_map is true
     if (!origin_valid && !adjustSensorOrigin(ox, oy, wx, wy))
     {
       continue;
@@ -592,7 +592,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   }
 }
 
-bool ObstacleLayer::adjustSensorOrigin(double &ox, double &oy, double wx, double wy) const
+bool ObstacleLayer::adjustSensorOrigin(double& ox, double& oy, double wx, double wy) const
 {
   // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
   Linestring sensor_ray;
@@ -600,8 +600,12 @@ bool ObstacleLayer::adjustSensorOrigin(double &ox, double &oy, double wx, double
   bg::append(sensor_ray, Point(wx, wy));
 
   std::vector<Point> intersection_points;
+
+  // find the intersection between the map and the line defined by the sensor ray
   bg::intersection(sensor_ray, map_boundary_, intersection_points);
 
+  // the map is a rectangle, so there should be two intersection points
+  // otherwise, sensor's ray is completely outside the map
   if (intersection_points.size() != 2)
   {
     return false;
@@ -625,7 +629,6 @@ bool ObstacleLayer::adjustSensorOrigin(double &ox, double &oy, double wx, double
   }
   return true;
 }
-
 
 void ObstacleLayer::activate()
 {

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -334,7 +334,11 @@ void ObstacleLayer::pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& 
 void ObstacleLayer::updateOrigin(double new_origin_x, double new_origin_y)
 {
   Costmap2D::updateOrigin(new_origin_x, new_origin_y);
+  updateMapPolygon();
+}
 
+void ObstacleLayer::updateMapPolygon()
+{
   map_boundary_.clear();
   const double origin_x = origin_x_, origin_y = origin_y_;
   const double map_end_x = origin_x + size_x_ * resolution_;
@@ -346,12 +350,14 @@ void ObstacleLayer::updateOrigin(double new_origin_x, double new_origin_y)
   bg::append(map_boundary_.outer(), Point(origin_x, origin_y));
 }
 
+
 void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                           double* min_y, double* max_x, double* max_y)
 {
   if (rolling_window_)
     updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
   useExtraBounds(min_x, min_y, max_x, max_y);
+  updateMapPolygon();
 
   bool current = true;
   std::vector<Observation> observations, clearing_observations;
@@ -522,7 +528,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     return;
   }
 
-
   // we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
   double origin_x = origin_x_, origin_y = origin_y_;
   double map_end_x = origin_x + size_x_ * resolution_;
@@ -540,15 +545,15 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     double wx = *iter_x;
     double wy = *iter_y;
 
-    // now we also need to make sure that the enpoint we're raytracing
-    // to isn't off the costmap and scale if necessary
-    double a = wx - ox;
-    double b = wy - oy;
-
     if (!origin_valid && !adjustSensorOrigin(ox, oy, wx, wy))
     {
       continue;
     }
+
+    // now we also need to make sure that the enpoint we're raytracing
+    // to isn't off the costmap and scale if necessary
+    double a = wx - ox;
+    double b = wy - oy;
 
     // the minimum value to raytrace from is the origin
     if (wx < origin_x)

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -544,39 +544,37 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     {
       continue;
     }
-    else
+    
+    // now we also need to make sure that the enpoint we're raytracing
+    // to isn't off the costmap and scale if necessary
+    double a = wx - ox;
+    double b = wy - oy;
+
+    // the minimum value to raytrace from is the origin
+    if (wx < origin_x)
     {
-      // now we also need to make sure that the enpoint we're raytracing
-      // to isn't off the costmap and scale if necessary
-      double a = wx - ox;
-      double b = wy - oy;
-  
-      // the minimum value to raytrace from is the origin
-      if (wx < origin_x)
-      {
-        double t = (origin_x - ox) / a;
-        wx = origin_x;
-        wy = oy + b * t;
-      }
-      if (wy < origin_y)
-      {
-        double t = (origin_y - oy) / b;
-        wx = ox + a * t;
-        wy = origin_y;
-      }
-      // the maximum value to raytrace to is the end of the map
-      if (wx > map_end_x)
-      {
-        double t = (map_end_x - ox) / a;
-        wx = map_end_x - .001;
-        wy = oy + b * t;
-      }
-      if (wy > map_end_y)
-      {
-        double t = (map_end_y - oy) / b;
-        wx = ox + a * t;
-        wy = map_end_y - .001;
-      }
+      double t = (origin_x - ox) / a;
+      wx = origin_x;
+      wy = oy + b * t;
+    }
+    if (wy < origin_y)
+    {
+      double t = (origin_y - oy) / b;
+      wx = ox + a * t;
+      wy = origin_y;
+    }
+    // the maximum value to raytrace to is the end of the map
+    if (wx > map_end_x)
+    {
+      double t = (map_end_x - ox) / a;
+      wx = map_end_x - .001;
+      wy = oy + b * t;
+    }
+    if (wy > map_end_y)
+    {
+      double t = (map_end_y - oy) / b;
+      wx = ox + a * t;
+      wy = map_end_y - .001;
     }
 
     // now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
@@ -595,8 +593,8 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   }
 }
 
-bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double& wx,
-                                       double& wy) const
+bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx,
+                                       double wy) const
 {
   // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
   Linestring sensor_ray;
@@ -623,22 +621,17 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   // copy original sensor origin
   const double original_ox = ox;
   const double original_oy = oy;
-  double end_x, end_y;
 
   // Choose the closest intersection point as origin
   if (distance1 < distance2)
   {
     ox = intersection1.x();
     oy = intersection1.y();
-    end_x = intersection2.x();
-    end_y = intersection2.y();
   }
   else
   {
     ox = intersection2.x();
     oy = intersection2.y();
-    end_x = intersection1.x();
-    end_y = intersection1.y();
   }
 
   // check if the distance between new origin and original sensor's origin is within range
@@ -654,16 +647,6 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   {
     return false;
   }
-
-  // scale the endpoint to the second intersection point 
-  // if the distance between the new origin and endpoint is greater than second intersection point and the new origin
-  // this means the endpoint is outside the map, so we put it on the second intersection point (inside the map)
-  if (std::hypot(end_x - ox, end_y - oy) < std::hypot(wx - ox, wy - oy))
-  {
-    wx = end_x;
-    wy = end_y;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
# Description
[AB#17690](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/17690)
Add the option to raytrace free space even if sensor is outside the map



https://github.com/user-attachments/assets/da8e5269-d2f9-4618-9b59-6277bc414067



