### PR TITLE
Check the cost of the center point of the robot and return if it's non-traversable space

### DIFF
--- a/base_local_planner/src/costmap_model.cpp
+++ b/base_local_planner/src/costmap_model.cpp
@@ -49,7 +49,7 @@ namespace base_local_planner {
     // returns:
     //  -1 if footprint covers at least a lethal obstacle cell, or
     //  -2 if footprint covers at least a no-information cell, or
-    //  -3 if footprint is [partially] outside of the map, or
+    //  -3 if footprint is [partially] outside the map, or
     //  a positive value for traversable space
 
     //used to put things into grid coordinates
@@ -59,13 +59,15 @@ namespace base_local_planner {
     if(!costmap_.worldToMap(position.x, position.y, cell_x, cell_y))
       return -3.0;
 
+    //check its cost, so we can skip footprint check if it's already non-traversable space
+    unsigned char cost = costmap_.getCost(cell_x, cell_y);
+    if(cost == NO_INFORMATION)
+      return -2.0;
+    if(cost == LETHAL_OBSTACLE || cost == INSCRIBED_INFLATED_OBSTACLE)
+      return -1.0;
+
     //if number of points in the footprint is less than 3, we'll just assume a circular robot
     if(footprint.size() < 3){
-      unsigned char cost = costmap_.getCost(cell_x, cell_y);
-      if(cost == NO_INFORMATION)
-        return -2.0;
-      if(cost == LETHAL_OBSTACLE || cost == INSCRIBED_INFLATED_OBSTACLE)
-        return -1.0;
       return cost;
     }
 


### PR DESCRIPTION
[AB#18500](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/18500)

when there's a small obstacle right in front of the robot and `obstacle_approach_distance` is significant, the enlarged footprint can engulf the obstacle and so the robot is not considered in collision:

https://github.com/user-attachments/assets/e29ac988-edad-4a6d-89b2-e2b15bc093b1

This cannot happen if we check also the cell at the center of the robot, as it will enter inflated space as soon as we start moving:

https://github.com/user-attachments/assets/c962dff3-1c8d-4afe-b200-2d5d038a66d7

Other algorithms check the fp cost the same way, e.g. [Hybrid A*](https://github.com/rapyuta-robotics/smac_planner/blob/db355171656e64de55f45554286733dd5deebd02/src/collision_checker.cpp#L132).
In theory this should also provide a small increase in performance, as checking a cell is much faster than the checking the footprint lines

