### PR TITLE
Fix floating point issue in costmap_2d boundaries

### DIFF
--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -610,11 +610,12 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   bg::intersection(sensor_ray, map_boundary_, intersection_points);
 
   // function to slightly shift the origin inwards to avoid floating point errors
-  const auto shift_inwards = [&ox, &oy, &wx, &wy]()
+  const auto shift_center_inwards = [&ox, &oy, &wx, &wy]()
   {
-    static constexpr const double eps = 0.001;
-    const double vx = (wx - ox) / std::hypot(wx - ox, wy - oy);
-    const double vy = (wy - oy) / std::hypot(wx - ox, wy - oy);
+    static constexpr double eps = 0.001;
+    const double magnitude = std::hypot(wx - ox, wy - oy);
+    const double vx = (wx - ox) / magnitude;
+    const double vy = (wy - oy) / magnitude;
     ox += eps * vx;
     oy += eps * vy;
   };
@@ -639,7 +640,7 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
       return false;
     }
 
-    shift_inwards();
+    shift_center_inwards();
     return true;
   }
 
@@ -675,7 +676,7 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
     return false;
   }
 
-  shift_inwards();
+  shift_center_inwards();
   return true;
 }
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -595,12 +595,10 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx,
                                        double wy) const
 {
-  static constexpr const double eps = 0.001;
-
   // copy original sensor origin
   const double original_ox = ox;
   const double original_oy = oy;
-  
+
   // Define the sensor ray as a linestring (from the sensor origin to the endpoint)
   Linestring sensor_ray;
   bg::append(sensor_ray, Point(ox, oy));
@@ -610,6 +608,16 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
 
   // find the intersection between the map and the line defined by the sensor ray
   bg::intersection(sensor_ray, map_boundary_, intersection_points);
+
+  // function to slightly shift the origin inwards to avoid floating point errors
+  const auto shift_inwards = [&ox, &oy, &wx, &wy]()
+  {
+    static constexpr const double eps = 0.001;
+    const double vx = (wx - ox) / std::hypot(wx - ox, wy - oy);
+    const double vy = (wy - oy) / std::hypot(wx - ox, wy - oy);
+    ox += eps * vx;
+    oy += eps * vy;
+  };
 
   // the map is a rectangle, so there should be at least one intersection point
   // and at maximum 2 intersection points
@@ -630,10 +638,8 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
     {
       return false;
     }
-    
-    // shift origin slightly inward
-    ox += eps * (wx - ox);  
-    oy += eps * (wy - oy);
+
+    shift_inwards();
     return true;
   }
 
@@ -646,14 +652,13 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   // Choose the closest intersection point as origin
   if (distance1 < distance2)
   {
-    // shift both points slightly
-    ox = intersection1.x() + eps * (wx - ox);  
-    oy = intersection1.y() + eps * (wy - oy);
+    ox = intersection1.x();
+    oy = intersection1.y();
   }
   else
   {
-    ox = intersection2.x() + eps * (wx - ox);
-    oy = intersection2.y() + eps * (wy - oy);
+    ox = intersection2.x();
+    oy = intersection2.y();
   }
 
   // check if the distance between new origin and original sensor's origin is within range
@@ -669,6 +674,8 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   {
     return false;
   }
+
+  shift_inwards();
   return true;
 }
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -549,7 +549,6 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     // to isn't off the costmap and scale if necessary
     double a = wx - ox;
     double b = wy - oy;
-
     // the minimum value to raytrace from is the origin
     if (wx < origin_x)
     {
@@ -596,6 +595,8 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, double& ox, double& oy, double wx,
                                        double wy) const
 {
+  static constexpr const double eps = 0.001;
+
   // copy original sensor origin
   const double original_ox = ox;
   const double original_oy = oy;
@@ -629,6 +630,10 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
     {
       return false;
     }
+    
+    // shift origin slightly inward
+    ox += eps * (wx - ox);  
+    oy += eps * (wy - oy);
     return true;
   }
 
@@ -641,13 +646,14 @@ bool ObstacleLayer::adjustSensorOrigin(const Observation& clearing_observation, 
   // Choose the closest intersection point as origin
   if (distance1 < distance2)
   {
-    ox = intersection1.x();
-    oy = intersection1.y();
+    // shift both points slightly
+    ox = intersection1.x() + eps * (wx - ox);  
+    oy = intersection1.y() + eps * (wy - oy);
   }
   else
   {
-    ox = intersection2.x();
-    oy = intersection2.y();
+    ox = intersection2.x() + eps * (wx - ox);
+    oy = intersection2.y() + eps * (wy - oy);
   }
 
   // check if the distance between new origin and original sensor's origin is within range


### PR DESCRIPTION
# Description
[AB#20987](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/20987)
Intersection points are in the boundary of the map, thus we might have floating point issue.
And this check will fail:

```
// check for legality just in case
    if (!worldToMap(wx, wy, x1, y1) || !worldToMap(ox, oy, x0, y0))
      continue;
```

Video of the issue:

https://github.com/user-attachments/assets/7864d20b-6aab-4a35-8dfb-bcf73af9c10b

After the fix:

https://github.com/user-attachments/assets/939c3542-246d-42a0-b540-f126063c89e6


