### PR TITLE
Update padFootprint function

### DIFF
--- a/costmap_2d/include/costmap_2d/footprint.h
+++ b/costmap_2d/include/costmap_2d/footprint.h
@@ -100,6 +100,13 @@ void transformFootprint(double x, double y, double theta, const std::vector<geom
                         geometry_msgs::PolygonStamped & oriented_footprint);
 
 /**
+ * @brief  Calculate the centroid of a vector of 2D points.
+ * @param  footprint A vector of points (type geometry_msgs::Point) representing a 2D polygon (footprint).
+ * @return The centroid of the footprint as a geometry_msgs::Point.
+ */
+geometry_msgs::Point calculateCentroid(const std::vector<geometry_msgs::Point>& footprint);
+
+/**
  * @brief Adds the specified amount of padding to the footprint (in place)
  */
 void padFootprint(std::vector<geometry_msgs::Point>& footprint, double padding);

--- a/costmap_2d/src/footprint.cpp
+++ b/costmap_2d/src/footprint.cpp
@@ -152,8 +152,8 @@ void padFootprint(std::vector<geometry_msgs::Point>& footprint, double padding)
       double dx = point.x - footprint_center.x;
       double dy = point.y - footprint_center.y;
 
-      point.x = footprint_center.x + dx * padding;
-      point.y = footprint_center.y + dy * padding;
+      point.x = footprint_center.x + dx * (1 + padding);
+      point.y = footprint_center.y + dy * (1 + padding);
   }
 }
 

--- a/costmap_2d/src/footprint.cpp
+++ b/costmap_2d/src/footprint.cpp
@@ -139,21 +139,27 @@ void padFootprint(std::vector<geometry_msgs::Point>& footprint, double padding)
 {
   geometry_msgs::Point footprint_center;
   double sum_x = 0.0, sum_y = 0.0;
+
   for (const auto& point : footprint)
   {
-      sum_x += point.x;
-      sum_y += point.y;
+    sum_x += point.x;
+    sum_y += point.y;
   }
   footprint_center.x = sum_x / footprint.size();
   footprint_center.y = sum_y / footprint.size();
 
   for (auto& point : footprint)
   {
-      double dx = point.x - footprint_center.x;
-      double dy = point.y - footprint_center.y;
+    double dx = point.x - footprint_center.x;
+    double dy = point.y - footprint_center.y;
 
-      point.x = footprint_center.x + dx * (1 + padding);
-      point.y = footprint_center.y + dy * (1 + padding);
+    double distance = std::sqrt(dx * dx + dy * dy);
+
+    if (distance > 0.0)
+    {
+      point.x += padding * (dx / distance);
+      point.y += padding * (dy / distance);
+    }
   }
 }
 

--- a/costmap_2d/src/footprint.cpp
+++ b/costmap_2d/src/footprint.cpp
@@ -137,12 +137,23 @@ void transformFootprint(double x, double y, double theta, const std::vector<geom
 
 void padFootprint(std::vector<geometry_msgs::Point>& footprint, double padding)
 {
-  // pad footprint in place
-  for (unsigned int i = 0; i < footprint.size(); i++)
+  geometry_msgs::Point footprint_center;
+  double sum_x = 0.0, sum_y = 0.0;
+  for (const auto& point : footprint)
   {
-    geometry_msgs::Point& pt = footprint[ i ];
-    pt.x += sign0(pt.x) * padding;
-    pt.y += sign0(pt.y) * padding;
+      sum_x += point.x;
+      sum_y += point.y;
+  }
+  footprint_center.x = sum_x / footprint.size();
+  footprint_center.y = sum_y / footprint.size();
+
+  for (auto& point : footprint)
+  {
+      double dx = point.x - footprint_center.x;
+      double dy = point.y - footprint_center.y;
+
+      point.x = footprint_center.x + dx * padding;
+      point.y = footprint_center.y + dy * padding;
   }
 }
 

--- a/costmap_2d/src/footprint.cpp
+++ b/costmap_2d/src/footprint.cpp
@@ -135,25 +135,34 @@ void transformFootprint(double x, double y, double theta, const std::vector<geom
   }
 }
 
+geometry_msgs::Point calculateCentroid(const std::vector<geometry_msgs::Point>& footprint)
+{
+    geometry_msgs::Point center;
+    double sum_x = 0.0, sum_y = 0.0;
+
+    for (const auto& point : footprint)
+    {
+        sum_x += point.x;
+        sum_y += point.y;
+    }
+
+    if (!footprint.empty()) {
+        center.x = sum_x / footprint.size();
+        center.y = sum_y / footprint.size();
+    }
+
+    return center;
+}
+
 void padFootprint(std::vector<geometry_msgs::Point>& footprint, double padding)
 {
-  geometry_msgs::Point footprint_center;
-  double sum_x = 0.0, sum_y = 0.0;
-
-  for (const auto& point : footprint)
-  {
-    sum_x += point.x;
-    sum_y += point.y;
-  }
-  footprint_center.x = sum_x / footprint.size();
-  footprint_center.y = sum_y / footprint.size();
+  geometry_msgs::Point footprint_center = calculateCentroid(footprint);
 
   for (auto& point : footprint)
   {
     double dx = point.x - footprint_center.x;
     double dy = point.y - footprint_center.y;
-
-    double distance = std::sqrt(dx * dx + dy * dy);
+    double distance = std::hypot(dx, dy);
 
     if (distance > 0.0)
     {

--- a/costmap_2d/test/footprint_tests.cpp
+++ b/costmap_2d/test/footprint_tests.cpp
@@ -71,14 +71,14 @@ TEST( Costmap2DROS, padded_footprint_from_string_param )
   EXPECT_EQ( 3, footprint.size() );
 
   EXPECT_EQ( 1.66667f, footprint[0].x );
-  EXPECT_EQ( 1.66667f, footprint[0].y );
+  EXPECT_EQ( 1.33333f, footprint[0].y );
   EXPECT_EQ( 0.0f, footprint[0].z );
 
-  EXPECT_EQ( -1.66667f, footprint[1].x );
-  EXPECT_EQ( 1.66667f, footprint[1].y );
+  EXPECT_EQ( -1.33333f, footprint[1].x );
+  EXPECT_EQ( 1.33333f, footprint[1].y );
   EXPECT_EQ( 0.0f, footprint[1].z );
 
-  EXPECT_EQ( -1.66667f, footprint[2].x );
+  EXPECT_EQ( -1.33333f, footprint[2].x );
   EXPECT_EQ( -1.66667f, footprint[2].y );
   EXPECT_EQ( 0.0f, footprint[2].z );
 }

--- a/costmap_2d/test/footprint_tests.cpp
+++ b/costmap_2d/test/footprint_tests.cpp
@@ -70,17 +70,17 @@ TEST( Costmap2DROS, padded_footprint_from_string_param )
   std::vector<geometry_msgs::Point> footprint = cm.getRobotFootprint();
   EXPECT_EQ( 3, footprint.size() );
 
-  EXPECT_EQ( 1.66667f, footprint[0].x );
-  EXPECT_EQ( 1.33333f, footprint[0].y );
-  EXPECT_EQ( 0.0f, footprint[0].z );
+  EXPECT_EQ( 1.44721f, footprint[ 0 ].x );
+  EXPECT_EQ( 1.22361f, footprint[ 0 ].y );
+  EXPECT_EQ( 0.0f, footprint[ 0 ].z );
 
-  EXPECT_EQ( -1.33333f, footprint[1].x );
-  EXPECT_EQ( 1.33333f, footprint[1].y );
-  EXPECT_EQ( 0.0f, footprint[1].z );
+  EXPECT_EQ( -1.35355f, footprint[ 1 ].x );
+  EXPECT_EQ( 1.35355f, footprint[ 1 ].y );
+  EXPECT_EQ( 0.0f, footprint[ 1 ].z );
 
-  EXPECT_EQ( -1.33333f, footprint[2].x );
-  EXPECT_EQ( -1.66667f, footprint[2].y );
-  EXPECT_EQ( 0.0f, footprint[2].z );
+  EXPECT_EQ( -1.22361f, footprint[ 2 ].x );
+  EXPECT_EQ( -1.44721f, footprint[ 2 ].y );
+  EXPECT_EQ( 0.0f, footprint[ 2 ].z );
 }
 
 TEST( Costmap2DROS, radius_param )

--- a/costmap_2d/test/footprint_tests.cpp
+++ b/costmap_2d/test/footprint_tests.cpp
@@ -70,17 +70,17 @@ TEST( Costmap2DROS, padded_footprint_from_string_param )
   std::vector<geometry_msgs::Point> footprint = cm.getRobotFootprint();
   EXPECT_EQ( 3, footprint.size() );
 
-  EXPECT_EQ( 1.5f, footprint[ 0 ].x );
-  EXPECT_EQ( 1.5f, footprint[ 0 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 0 ].z );
+  EXPECT_EQ( 1.66667f, footprint[0].x );
+  EXPECT_EQ( 1.66667f, footprint[0].y );
+  EXPECT_EQ( 0.0f, footprint[0].z );
 
-  EXPECT_EQ( -1.5f, footprint[ 1 ].x );
-  EXPECT_EQ( 1.5f, footprint[ 1 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 1 ].z );
+  EXPECT_EQ( -1.66667f, footprint[1].x );
+  EXPECT_EQ( 1.66667f, footprint[1].y );
+  EXPECT_EQ( 0.0f, footprint[1].z );
 
-  EXPECT_EQ( -1.5f, footprint[ 2 ].x );
-  EXPECT_EQ( -1.5f, footprint[ 2 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 2 ].z );
+  EXPECT_EQ( -1.66667f, footprint[2].x );
+  EXPECT_EQ( -1.66667f, footprint[2].y );
+  EXPECT_EQ( 0.0f, footprint[2].z );
 }
 
 TEST( Costmap2DROS, radius_param )
@@ -155,7 +155,7 @@ TEST( Costmap2DROS, footprint_empty )
   // With no specification of footprint or radius, defaults to 0.46 meter radius plus 0.01 meter padding.
   EXPECT_EQ( 16, footprint.size() );
 
-  EXPECT_NEAR( 0.47f, footprint[ 0 ].x, 0.0001 );
+  EXPECT_NEAR( 0.47f, footprint[ 0 ].x, 0.001 );
   EXPECT_NEAR( 0.0f, footprint[ 0 ].y, 0.0001 );
   EXPECT_EQ( 0.0f, footprint[ 0 ].z );
 }

--- a/costmap_2d/test/footprint_tests.cpp
+++ b/costmap_2d/test/footprint_tests.cpp
@@ -70,17 +70,17 @@ TEST( Costmap2DROS, padded_footprint_from_string_param )
   std::vector<geometry_msgs::Point> footprint = cm.getRobotFootprint();
   EXPECT_EQ( 3, footprint.size() );
 
-  EXPECT_EQ( 1.44721f, footprint[ 0 ].x );
-  EXPECT_EQ( 1.22361f, footprint[ 0 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 0 ].z );
+  EXPECT_NEAR( 1.44721f, footprint[ 0 ].x, 0.0001f);
+  EXPECT_NEAR( 1.22361f, footprint[ 0 ].y, 0.0001f);
+  EXPECT_EQ( 0.0f, footprint[ 0 ].z);
 
-  EXPECT_EQ( -1.35355f, footprint[ 1 ].x );
-  EXPECT_EQ( 1.35355f, footprint[ 1 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 1 ].z );
+  EXPECT_NEAR( -1.35355f, footprint[ 1 ].x, 0.0001f);
+  EXPECT_NEAR( 1.35355f, footprint[ 1 ].y, 0.0001f);
+  EXPECT_EQ( 0.0f, footprint[ 1 ].z);
 
-  EXPECT_EQ( -1.22361f, footprint[ 2 ].x );
-  EXPECT_EQ( -1.44721f, footprint[ 2 ].y );
-  EXPECT_EQ( 0.0f, footprint[ 2 ].z );
+  EXPECT_NEAR( -1.22361f, footprint[ 2 ].x, 0.0001f);
+  EXPECT_NEAR( -1.44721f, footprint[ 2 ].y, 0.0001f);
+  EXPECT_EQ( 0.0f, footprint[ 2 ].z);
 }
 
 TEST( Costmap2DROS, radius_param )


### PR DESCRIPTION
[AB#44902](https://dev.azure.com/rapyuta-robotics/sootballs/_workitems/edit/44902)
Previously this function was scaling the footprint with respect to the coordinate frame 0,0 which could result in distortion. Also when the centroid is having large offset with 0,0 then it will just displace the footprint instead of padding.

Now it scales with respect to the centroid of the footprint.

![image](https://github.com/user-attachments/assets/3d2ad01c-c556-46da-b05c-e648a352e6e7)
![image](https://github.com/user-attachments/assets/b9c54097-5db0-4f5b-af45-c72ac897428d)
another case (10,10), (10,12), (12,12) , (12,10)
![image](https://github.com/user-attachments/assets/8f4bf020-c5ef-4687-8061-a80d297f02ac)
![image](https://github.com/user-attachments/assets/7fb65778-9d7f-4af7-8188-1fbee38888c8)

another case (0,0), (0,2), (2,2), (2,0)
![image](https://github.com/user-attachments/assets/a5340025-3ebd-4f5c-9b84-6e7440267e29)
![image](https://github.com/user-attachments/assets/9a86cdc0-1cee-471b-9e0d-03ca7b8b20d6)

I have also tested the behaviour with negative values of padding (shrinking the footprint)

