### PR TITLE
Fix worldToMapContinuous by flipping + 0.5f sign

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -231,8 +231,8 @@ bool Costmap2D::worldToMapContinuous(double wx, double wy, float& mx, float& my)
     return false;
   }
 
-  mx = static_cast<float>((wx - origin_x_) / resolution_) + 0.5f;
-  my = static_cast<float>((wy - origin_y_) / resolution_) + 0.5f;
+  mx = static_cast<float>((wx - origin_x_) / resolution_) - 0.5f;
+  my = static_cast<float>((wy - origin_y_) / resolution_) - 0.5f;
 
   return mx < size_x_ && my < size_y_;
 }


### PR DESCRIPTION
Not 100% why this works, but I guess it's because we are effectively undoing the addition of 0.5 done [here](https://github.com/rapyuta-robotics/ros-navigation/blob/93930b5d8ca9ffae66af5c35c5a2cf0396824965/costmap_2d/src/costmap_2d.cpp#L209-L210).

The funny part is that on nav2 it's still +, and it works there. But for our ported version of HA*, without this change, the goal always appears resolution/2 displaced up and to the right.

I guess there must be something different between costmap_2d 1 and 2. The good news are
- This method is only used by Hybrid A*
- We will change both together when moving to ROS 2
so no danger 
