### PR TITLE
feat: add min_vel_theta_spin for pure spin turn

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_limits.h
+++ b/base_local_planner/include/base_local_planner/local_planner_limits.h
@@ -53,6 +53,7 @@ public:
   double max_vel_theta;
   double max_vel_theta_spin;
   double min_vel_theta;
+  double min_vel_theta_spin;
   double acc_lim_x;
   double acc_lim_y;
   double acc_lim_theta;
@@ -80,6 +81,7 @@ public:
       double nmax_vel_theta,
       double nmax_vel_theta_spin,
       double nmin_vel_theta,
+      double nmin_vel_theta_spin,
       double nacc_lim_x,
       double nacc_lim_y,
       double nacc_lim_theta,
@@ -102,6 +104,7 @@ public:
         max_vel_theta(nmax_vel_theta),
         max_vel_theta_spin(nmax_vel_theta_spin),
         min_vel_theta(nmin_vel_theta),
+        min_vel_theta_spin(nmin_vel_theta_spin),
         acc_lim_x(nacc_lim_x),
         acc_lim_y(nacc_lim_y),
         acc_lim_theta(nacc_lim_theta),

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -162,7 +162,7 @@ bool LatchedStopRotateController::rotateToGoal(
   cmd_vel.linear.y = 0;
   double ang_diff = angles::shortest_angular_distance(yaw, goal_th);
 
-  double v_theta_samp = std::min(limits.max_vel_theta, std::max(limits.min_vel_theta, fabs(ang_diff)));
+  double v_theta_samp = std::min(limits.max_vel_theta, std::max(limits.min_vel_theta_spin, fabs(ang_diff)));
 
   //take the acceleration limits of the robot into account
   double max_acc_vel = fabs(vel_yaw) + acc_lim[2] * sim_period;

--- a/base_local_planner/src/local_planner_limits/__init__.py
+++ b/base_local_planner/src/local_planner_limits/__init__.py
@@ -26,6 +26,7 @@ def add_generic_localplanner_params(gen):
     gen.add("max_vel_theta", double_t, 0, "The absolute value of the maximum rotational velocity for the robot in rad/s",  1.0, 0)
     gen.add("max_vel_theta_spin", double_t, 0, "The absolute value of the maximum rotational velocity for the robot in rad/s when spinning in place. Should be greater than or equal to max_vel_theta",  1.0, 0)
     gen.add("min_vel_theta", double_t, 0, "The absolute value of the minimum rotational velocity for the robot in rad/s", 0.4, 0)
+    gen.add("min_vel_theta_spin", double_t, 0, "The absolute value of the minimum rotational velocity for the robot in rad/s when spinning in place. Should be greater than or equal to min_vel_theta", 0.4, 0)
 
     # acceleration
     gen.add("acc_lim_x", double_t, 0, "The acceleration limit of the robot in the x direction", 2.5, 0, 20.0)

--- a/base_local_planner/src/simple_trajectory_generator.cpp
+++ b/base_local_planner/src/simple_trajectory_generator.cpp
@@ -208,8 +208,10 @@ bool SimpleTrajectoryGenerator::generateTrajectory(
 
   // make sure that the robot would at least be moving with one of
   // the required minimum velocities for translation and rotation (if set)
+  bool is_spin = vmag < 2.0 * limits_->min_vel_trans;
+  double eff_min_vel_theta = is_spin ? limits_->min_vel_theta_spin : limits_->min_vel_theta;
   if ((limits_->min_vel_trans >= 0 && vmag + eps < limits_->min_vel_trans) &&
-      (limits_->min_vel_theta >= 0 && fabs(sample_target_vel[2]) + eps < limits_->min_vel_theta)) {
+      (eff_min_vel_theta >= 0 && fabs(sample_target_vel[2]) + eps < eff_min_vel_theta)) {
     return false;
   }
   // make sure we do not exceed max diagonal (x+y) translational velocity (if set)

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -83,6 +83,7 @@ namespace dwa_local_planner {
       _latest_limits.max_vel_theta = config.max_vel_theta;
       _latest_limits.max_vel_theta_spin = config.max_vel_theta_spin;
       _latest_limits.min_vel_theta = config.min_vel_theta;
+      _latest_limits.min_vel_theta_spin = config.min_vel_theta_spin;
       _latest_limits.acc_lim_x = config.acc_lim_x;
       _latest_limits.acc_lim_y = config.acc_lim_y;
       _latest_limits.acc_lim_theta = config.acc_lim_theta;


### PR DESCRIPTION
[AB#115379](https://dev.azure.com/rapyuta-robotics/AMR/_workitems/edit/115379)
currently we have max_vel_theta_spin param for in place turn behaviour. Adding a separate min_vel_theta_spin param for this will make the robot spin faster and reach max_vel_theta_spin often.